### PR TITLE
Make login and signup pages scale based on screen size.

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -1378,11 +1378,6 @@ li.selected > a .favicon-wrap {
 	}
 }
 
-.signup-container {
-	margin: 0 auto;
-	width: 548px;
-}
-
 /*------------------------------------------------------------------------------
 Settings
 ------------------------------------------------------------------------------*/
@@ -2355,15 +2350,19 @@ Mobile
 }
 
 /*------------------------------------------------------------------------------
-Login
+Login and Sign Up
 ------------------------------------------------------------------------------*/
-.login {
+.login, .signup {
 	background-color: #efefef;
 	.bar {
 		display: none;
 	}
 	.login-wrap {
 		max-width: 512px;
+		margin: 0 auto;
+	}
+	.signup-wrap {
+		max-width: 548px;
 		margin: 0 auto;
 	}
 	svg {
@@ -2376,7 +2375,8 @@ Login
 		}
 	}
 	input[type="email"],
-	input[type="password"] {
+	input[type="password"],
+	input[type="text"] {
 		width: 94%;
 		padding-left: 3%;
 		padding-right: 3%;
@@ -2389,43 +2389,14 @@ Login
 		display: block;
 		margin: 15px 0 0 0;
 	}
-}
-
-
-/*------------------------------------------------------------------------------
-Sign Up
-------------------------------------------------------------------------------*/
-.signup {
-	background-color: #efefef;
-	font-size: 18px;
-	.bar {
-		display: none;
-	}
-	.login-wrap {
-		width: 512px;
-		margin: 0 auto;
-	}
-	svg {
-		width: 78px;
-		height: 65px;
-		display: block;
-		margin: 0 auto 29px auto;
-		* {
-			fill: #cccccc;
-		}
-	}
-	input[type="submit"] {
-		padding: 10px 25px;
-		font-size: 18px;
-	}
 	.form-wrap {
 		margin-left: 20px;
-		width: 327px;
+		max-width: 327px;
 		float: left;
 	}
 	.promo-wrap {
 		margin-left: 20px;
-		width: 139px;
+		max-width: 139px;
 		float: left;
 	}
 	.radio {
@@ -2434,5 +2405,15 @@ Sign Up
 	}
 	hr {
 		margin: 20px 0;
+	}
+}
+
+.signup {
+	input[type="email"],
+	input[type="password"] {
+		width: 94%;
+		max-width: 300px;
+		padding-left: 3%;
+		padding-right: 3%;
 	}
 }

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
 <% @class = 'signup' %>
-<div class="signup-container pad-bottom">
+<div class="signup-wrap pad-bottom">
   <a href="/"><%= render partial: "shared/svg/logo" %></a>
   
   <h3 class="box-header">Sign Up</h3>


### PR DESCRIPTION
This makes the login page look much nicer on small screens.

On a big screen it looks almost exactly how it used to (except the ends of the email and password inputs line up with the login button now):

![screenshot from 2013-08-28 18 29 25](https://f.cloud.github.com/assets/1447206/1046585/7b9d8c82-1042-11e3-982d-4508b0d231da.png)

But on a small screen it looks much better:

![screenshot from 2013-08-28 18 29 35](https://f.cloud.github.com/assets/1447206/1046588/841cb090-1042-11e3-8ed2-b953919cd1dc.png)

For reference, here's how it looks now:

![screenshot from 2013-08-28 18 33 20](https://f.cloud.github.com/assets/1447206/1046592/9d3ab9f0-1042-11e3-9156-9a0350a3d1f8.png)
