### PR TITLE
Only use scrollbars when the content is long enough to require one.

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -716,7 +716,7 @@ Structure
 	bottom: 52px;
 	left: 0;
 	right: 0;
-	overflow-y: scroll;
+	overflow-y: auto;
 	overflow-x: hidden;
 	-webkit-overflow-scrolling: touch;
 	ul {
@@ -918,7 +918,7 @@ li.selected > a .favicon-wrap {
 	bottom: 0;
 	left: 0;
 	right: 0;
-	overflow-y: scroll;
+	overflow-y: auto;
 	overflow-x: hidden;
 	-webkit-overflow-scrolling: touch;
 	ul {
@@ -1054,7 +1054,7 @@ li.selected > a .favicon-wrap {
 	left:0;
 	right:0;
 	margin: 0;
-	overflow-y: scroll;
+	overflow-y: auto;
 	overflow-x: hidden;
 	-webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
I've always used Feedbin on Firefox, so I never noticed how much better it looks on Safari, without the scrollbar place-holders.

Before patch (ugly grey bars where the scrollbars should be):

![screenshot from 2013-08-28 19 26 26](https://f.cloud.github.com/assets/1447206/1046787/2109a636-104a-11e3-8271-8a3da4f0d77d.png)

After patch (no scrollbars when we don't need them):

![screenshot from 2013-08-28 19 25 59](https://f.cloud.github.com/assets/1447206/1046788/26c411a6-104a-11e3-93b7-e3c03ea33785.png)

Also after patch (scrollbars appear when needed):

![screenshot from 2013-08-28 19 28 07](https://f.cloud.github.com/assets/1447206/1046793/4d2433ee-104a-11e3-8dbb-8417414e6fa7.png)
