### PR TITLE
Do not calculate stats unless LIBRATO_TOKEN is set

### DIFF
--- a/app/workers/send_stats.rb
+++ b/app/workers/send_stats.rb
@@ -5,9 +5,11 @@ class SendStats
   MEGABYTE = 1024.0 * 1024.0
 
   def perform
-    memcached_stats
-    redis_stats
-    postgres_stats
+    if ENV['LIBRATO_TOKEN']
+      memcached_stats
+      redis_stats
+      postgres_stats
+    end
   end
   
   def memcached_stats


### PR DESCRIPTION
Only attempt to send statistics if it's technically possible. This removes some console noise when running foreman for development.
