### PR TITLE
Stop changing the `title` text when there is nothing to change.

### DIFF
--- a/app/assets/javascripts/_site.js.coffee
+++ b/app/assets/javascripts/_site.js.coffee
@@ -141,7 +141,8 @@ $.extend feedbin,
         else
           title = "Feedbin (#{count})"
 
-        $('title').text(title)
+        docTitle = $('title')
+        docTitle.text(title) unless docTitle.text() is title
     
   readability: (target) ->
     feedId = $('[data-feed-id]', target).data('feed-id')


### PR DESCRIPTION
This should fix feedbin/support#356. But please test it again before pulling into master.

Another possibility would be to build this check into the `updateTitle` function and change `updateReadCount` to use that function. This would keep all `<title>` manipulation DRY and to a minimum whenever it is used. The exact two lines would work.

(Sorry for the newline character at the end, GitHub’s online editor does that…)
