### PR TITLE
Stop changing the `title` text when there is nothing to change.

### DIFF
--- a/app/assets/javascripts/_site.js.coffee
+++ b/app/assets/javascripts/_site.js.coffee
@@ -107,7 +107,8 @@ $.extend feedbin,
     anchor.dispatchEvent event
 
   updateTitle: (title) ->
-    $('title').text(title)
+    docTitle = $('title')
+    docTitle.text(title) unless docTitle.text() is title
 
   autocomplete: ->
     $("#feed_tag_list").autocomplete
@@ -141,7 +142,7 @@ $.extend feedbin,
         else
           title = "Feedbin (#{count})"
 
-        $('title').text(title)
+        feedbin.updateTitle(title)
     
   readability: (target) ->
     feedId = $('[data-feed-id]', target).data('feed-id')


### PR DESCRIPTION
This is a superior (IMHO) alternative to #30, fixing feedbin/support#356.
