### PR TITLE
Remove list dots in the screenshot nav on the home page.

### DIFF
--- a/app/assets/stylesheets/_home.scss
+++ b/app/assets/stylesheets/_home.scss
@@ -338,6 +338,7 @@
 			width: 96px;
 			margin: 0;
 			padding: 0;
+			list-style-type: none;
 			li {
 				margin-left: 10px;
 				float: right;


### PR DESCRIPTION
Before:

![screenshot from 2013-09-23 22 05 17](https://f.cloud.github.com/assets/1447206/1197191/7ef839cc-24ce-11e3-8e8e-4a38bd6afcec.png)

After:

![screenshot from 2013-09-23 22 05 30](https://f.cloud.github.com/assets/1447206/1197192/81a4c802-24ce-11e3-8bfb-b812ae1e8946.png)
