### PR TITLE
Link site name on /settings/feeds, instead of printing url

### DIFF
--- a/app/views/settings/feeds.html.erb
+++ b/app/views/settings/feeds.html.erb
@@ -14,9 +14,8 @@
             <td width="15"><%= check_box_tag "subscription_ids[]", subscription.id %></td>
             <td>
               <%= f.text_field :title %>
-              <br /><small title="Original title"><%= subscription.original_title %></small>
+              <br /><small title="Original title"><%= link_to subscription.original_title, subscription.site_url %></small>
               <small class="highlight break-word" title="Feed URL"><%= subscription.feed_url %></small>
-              <small class="highlight break-word" title="Site URL"><%= subscription.site_url %></small>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
Instead of displaying two links on the list of feeds, let's just link the original title to the site url.
