### PR TITLE
Only add scrollbars to <pre> elements if there's too much content to display

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -2044,7 +2044,7 @@ li.selected > a .favicon-wrap {
 
 	pre {
 		display: block;
-		overflow-x: scroll;
+		overflow-x: auto;
 		white-space: pre;
 		word-wrap: normal;
 	}


### PR DESCRIPTION
These scrollbars make me sad:

![screen shot 2013-09-29 at 1 38 25 pm](https://f.cloud.github.com/assets/1447206/1233712/cbfabd20-293e-11e3-854a-8f8b7f7c3021.png)

I'm going to try to figure out why the code indentation isn't working too..
