### PR TITLE
Set subscribe bar height to 20px (+10px padding) to match the new dropbox

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -1044,6 +1044,7 @@ Structure
 		margin: 0;
 		input[type="url"],
 		input[type="text"] {
+		    height: 20px;
 			width: 224px;
 			margin-bottom: 0;
 			padding: 5px 5px 5px 86px;


### PR DESCRIPTION
See issue  #50. This makes the new dropdown box in the subscribe menu fix in Firefox.

Before:

![screen shot 2013-10-10 at 7 49 38 pm](https://f.cloud.github.com/assets/1447206/1311741/cbf8aebc-3218-11e3-9330-51b5d36574aa.png)

After:

![screen shot 2013-10-10 at 8 00 14 pm](https://f.cloud.github.com/assets/1447206/1311745/ed73e610-3218-11e3-939b-c3d7c71043f7.png)

Chrome and Safari look the same.
