### PR TITLE
Update menu button's height and width to 48px to match the header bar's height

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -1215,8 +1215,8 @@ Structure
 	z-index: 1;
 	.menu-button {
 		background: image-url("icon-menu.svg") center center no-repeat;
-		width: 46px;
-		height: 46px;
+		width: 48px;
+		height: 48px;
 		margin-left: auto;
 		overflow: auto;
 	}


### PR DESCRIPTION
I guess I got the height wrong, or maybe it changed after I wrote the settings menu pull request.

Now:

![screenshot from 2013-11-02 19 35 38](https://f.cloud.github.com/assets/1447206/1460244/15d356d6-4420-11e3-9d19-ee173a645f32.png)

Fixed:

![screenshot from 2013-11-02 19 36 49](https://f.cloud.github.com/assets/1447206/1460245/198a3c4a-4420-11e3-9828-e8065728a1a0.png)
