### PR TITLE
Add "Log Out" link to the settings dropbox menu.

### DIFF
--- a/app/views/layouts/_settings_nav.html.erb
+++ b/app/views/layouts/_settings_nav.html.erb
@@ -8,6 +8,7 @@
     <li><%= link_to 'Billing', settings_billing_path, class: is_active?('settings', 'billing') %></li>
     <li><%= link_to 'Import/Export', settings_import_export_path, class: is_active?('settings', 'import_export') %></li>
     <li><%= link_to 'Help', settings_help_path, class: is_active?('settings', 'help') %></li>
+    <li><%= link_to 'Log Out', logout_path, method: 'delete', class: 'logout-link' %></li>
   </ul>
   <ul class="nav nav-small">
     <li class="home-link"><a href="/home">Home</a></li>


### PR DESCRIPTION
This adds a logout link to the mobile site.

Before:

<img src="https://f.cloud.github.com/assets/1447206/1461885/633066c0-44d5-11e3-92ed-3c673ce121b2.png" width="384"/>

After:

<img src="https://f.cloud.github.com/assets/1447206/1461886/6332d266-44d5-11e3-93be-93e2059413d7.png" width="384"/>

The logout link in the normal settings menu is already hidden on line 2639 in _site.scss (since I meant to do this in the original commit):

```
.settings {
    .content {
        display: table;
        border-collapse: collapse;
        width: 100%;
        .settings-nav {
            list-style-type: none;
            display: table-cell;
            width: 40%;
            padding-top: 20px;
            > * {
                margin-right: 20px;
                margin-left: auto;
            }
            @media (max-width: 527px) {
                display: none;
            }
            .logout-link {
                display: none; <--- here
            }
        }
        /* etc.
    }
    /* etc. */
}
```
