### PR TITLE
Fix the height of the header bar on the settings page

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -2641,6 +2641,7 @@ Settings
 			}
 		}
 		.settings-content {
+			border-top: 1px solid #CCC;
 			display: table-cell;
 			background-color: white;
 			vertical-align: top;
@@ -2675,7 +2676,6 @@ Settings
 		margin-top: 20px;
 	}
 	.bar {
-		border-bottom: 1px solid #CCC;
 		.logo {
 			display: inline-block;
 		}


### PR DESCRIPTION
On the settings page, the border between the menu bar and the content was styled on the header, which due to HTML5's horrible box model means that it's subtracted from the height. This commit moves the `border-bottom` on the header to a `border-top` on the content for consistency with the main page (where the border is rendered individually by the table cells).

I chose to move this rather than set `height: 49px`, since that seemed annoying to maintain.

Before:

<img src="https://f.cloud.github.com/assets/1447206/1461931/be4e14ba-44d7-11e3-9019-5aa2236bef1e.png" width="384"/>

After:

<img src="https://f.cloud.github.com/assets/1447206/1461930/be3486e4-44d7-11e3-9fcf-042f1da98826.png" width="384"/>
