### PR TITLE
Add support for paging articles up and down

### DIFF
--- a/app/assets/javascripts/keyboard.js.coffee
+++ b/app/assets/javascripts/keyboard.js.coffee
@@ -59,10 +59,10 @@ class feedbin.Keyboard
 
   navigateFeedbin: (combo) ->
     @setEnvironment()
-    if 'pageup' == combo
+    if 'pagedown' == combo
       if 'entry-content' == @selectedColumnName() || feedbin.isFullScreen()
         @scrollContent(@contentHeight() - 100, 'down')
-    else if 'pagedown' == combo
+    else if 'pageup' == combo
       if 'entry-content' == @selectedColumnName() || feedbin.isFullScreen()
         @scrollContent(@contentHeight() - 100, 'up')
     else if 'down' == combo || 'j' == combo


### PR DESCRIPTION
Currently, Page Up and Page Down don't have any effect. I've made some changes to let those keys scroll the article content in large steps.

It adds `pageup` and `pagedown` event handlers which scroll the article content by `article content's clientHeight - 100`. The `100` is an approximation of 4-5 lines of text in typical font sizes.
