### PR TITLE
Put title into feed link

### DIFF
--- a/app/presenters/feed_presenter.rb
+++ b/app/presenters/feed_presenter.rb
@@ -3,7 +3,7 @@ class FeedPresenter < BasePresenter
   presents :feed
 
   def feed_link(&block)
-    @template.link_to @template.feed_entries_path(feed), remote: true, class: 'feed-link', data: { behavior: 'selectable show_entries open_item feed_link', mark_read: {type: 'feed', data: feed.id, message: "Mark #{feed.title} as read?"}.to_json } do
+    @template.link_to @template.feed_entries_path(feed), remote: true, title: feed.title, class: 'feed-link', data: { behavior: 'selectable show_entries open_item feed_link', mark_read: {type: 'feed', data: feed.id, message: "Mark #{feed.title} as read?"}.to_json } do
       yield
     end
   end


### PR DESCRIPTION
It's really helpful with long feed names that doesn't fit into feeds
panel.
