### PR TITLE
Scroll feed entries to the middle of the entries column on keyboard navigation

### DIFF
--- a/app/assets/javascripts/keyboard.js.coffee
+++ b/app/assets/javascripts/keyboard.js.coffee
@@ -278,7 +278,7 @@ class feedbin.Keyboard
     if @item.length > 0
       @itemPosition = @getItemPosition()
       unless @itemInView()
-        @scrollOne()
+        @scrollItemToMiddle()
       @selected.removeClass('selected')
       @item.addClass('selected')
       @clickItem()
@@ -371,16 +371,8 @@ class feedbin.Keyboard
     bottom: (@item.offset().top - @columnOffsetTop) + @item.outerHeight() - drawer
     top: (@item.offset().top - @columnOffsetTop)
 
-  scrollOne: ->
-    if @itemAboveView
-      @scrollColumn @scrollTop + @itemPosition.top
-    else if @itemBelowView
-      if @selectedColumnName() == 'entries'
-        offset = 17 # above chrome's status bar
-      else
-        offset = 0
-      @scrollColumn (@itemPosition.bottom + @scrollTop + offset) - @containerHeight
-    else
+  scrollItemToMiddle: ->
+    @scrollColumn ((@scrollTop + @itemPosition.bottom) - (@containerHeight / 2))
 
   scrollColumn: (position) ->
     @selectedColumn.prop 'scrollTop', position


### PR DESCRIPTION
When browsing feeds via the keyboard, it's more useful to keep the currently selected feed entry in the middle of the screen. That way, the user can see what's coming up next. This change should leave navigation at the top and bottom of the list unchanged, and also has the advantage of being shorter than the previous method. It leaves mouse navigation unchanged. 

This resolves ticket #90.
