### PR TITLE
Add ImageMagick-devel to Fedora instructions, and make them just "on Fedora"

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ export AWS_ACCESS_KEY_ID=aoisjf3j23oij23f
 
 - [Mac OS X](doc/INSTALL-mac.md)
 - [Ubuntu](doc/INSTALL-ubuntu.md) (incomplete)
-- [Fedora 19](doc/INSTALL-fedora.md)
+- [Fedora](doc/INSTALL-fedora.md)
 
 
 ### Pair With Me

--- a/doc/INSTALL-fedora.md
+++ b/doc/INSTALL-fedora.md
@@ -1,11 +1,11 @@
-Feedbin Installation on Fedora 19
----------------------------------
+Feedbin Installation on Fedora
+------------------------------
 
 #### Feedbin Dependencies
 
 Install a bunch of dependencies:
 
-    sudo yum -y install gcc gcc-c++ git libcurl-devel libxml2-devel libxslt-devel postgresql postgresql-devel rubygems ruby-devel rubygem-bundler
+    sudo yum -y install gcc gcc-c++ git libcurl-devel libxml2-devel libxslt-devel postgresql postgresql-devel rubygems ruby-devel rubygem-bundler ImageMagick-devel
 
 Get Feedbin:
 


### PR DESCRIPTION
I'm looking into some things and noticed that the install instructions for Fedora were missing this package. Also, it seems kind of pointless to say the specific version, since that will change all the time.
