### PR TITLE
Change feed buttons (Unread/Starred/All) into tabs

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -1525,7 +1525,6 @@ $subscribe-wrap-height: 49px;
 .view-toolbar {
 	display: flex;
 	height: $toolbar-height;
-	border-bottom: 1px solid transparent;
 	@include border-color($border-color, $border-color-night, $border-color-sunset);
 	position: absolute;
 	left: 0;
@@ -1541,14 +1540,16 @@ $subscribe-wrap-height: 49px;
 		text-transform: uppercase;
 		font-weight: bold;
 		user-select: none;
-		border-left: 1px solid transparent;
+		border-width: 0 0 1px 1px;
+		border-style: solid;
 		@include border-color($border-color, $border-color-night, $border-color-sunset);
 		@include color($text-color-light, $text-color-light-night, $text-color-light-sunset);
 		&.selected {
 			@include color($text-color, $text-color-night, $text-color-sunset);
+			border-bottom-width: 0;
 		}
 		&:first-child {
-			border: none;
+			border-left-width: 0;
 		}
 	}
 }


### PR DESCRIPTION
This PR removes the bottom border of the selected feed view, i.e. it turns these buttons:
![screenshot 10-28-2014 at 3 41 18 p](https://cloud.githubusercontent.com/assets/510520/4811233/020f8232-5eb9-11e4-81f1-4989d7ab8e0c.png)
into these tabs:
![screenshot 10-28-2014 at 3 40 57 p](https://cloud.githubusercontent.com/assets/510520/4811232/0127f3e0-5eb9-11e4-8db3-1975918d736a.png)
