### PR TITLE
Only show edit button for selected feed

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -1615,7 +1615,7 @@ $subscribe-wrap-height: 49px;
 				padding: 8px;
 				@include background-color($list-background-color, $list-background-color-night, $list-background-color-sunset);
 			}
-			&:hover .rename-feed-button {
+			&.selected:hover .rename-feed-button {
 				display: block;
 			}
 			.rename-feed-input {


### PR DESCRIPTION
Hi @benubois,

I agree that the edit button is distracting when hovering over every feed. I think it is better to have the icon appear when hovering over selected feeds, rather than double clicking, because it has slightly higher affordance. Here's a one line change to fix that.
