### PR TITLE
Remove second escaping of feed title in `updateFeedTitles()`

### DIFF
--- a/app/assets/javascripts/_site.js.coffee
+++ b/app/assets/javascripts/_site.js.coffee
@@ -104,7 +104,7 @@ $.extend feedbin,
       feedId = $(@).data('feed-id')
       if (feedId of feedbin.data.user_titles)
         newTitle = feedbin.data.user_titles[feedId]
-        $(@).text(newTitle)
+        $(@).html(newTitle)
 
   queryString: (name) ->
     name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]")


### PR DESCRIPTION
When you rename a feed title inline, the occurrences of the new title elsewhere are double-escaped, so renaming a title to "Somebody's Blog", appears as "Somebody&#39;s Blog" elsewhere (until you refresh the page). This PR fixes that.
