### PR TITLE
Fix failing settings_controller_spec

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,0 +1,28 @@
+# wraps a Stripe::Customer instance
+class Customer
+  attr_reader :customer
+
+  delegate :id, to: :customer
+
+  def self.retrieve(customer_id)
+    new(Stripe::Customer.retrieve(customer_id))
+  end
+
+  def initialize(customer)
+    @customer = customer
+  end
+
+  def unpaid?
+    customer.try(:subscriptions).try(:first).try(:status) == "unpaid"
+  end
+
+  def reopen_account
+    invoice = Stripe::Invoice.all(customer: id, limit: 1).first
+    if invoice.closed
+      invoice.closed = false
+      invoice.save
+      invoice.pay
+    end
+  end
+end
+

--- a/spec/controllers/settings_controller_spec.rb
+++ b/spec/controllers/settings_controller_spec.rb
@@ -21,8 +21,13 @@ describe SettingsController do
 
   describe "#update_credit_card" do
     it "works" do
-      user = create(:user)
+      user = create(:user, customer_id: '1234')
       sign_in user
+
+      customer = double(:customer)
+      expect(Customer).to receive(:retrieve).with('1234').and_return(customer)
+      expect(customer).to receive(:unpaid?).and_return(true)
+      expect(customer).to receive(:reopen_account)
 
       post :update_credit_card, stripe_token: 'foobar'
 


### PR DESCRIPTION
It's failing due to an error raised by Stripe, which is that the user doesn't have a customer_id, so it can't look them up. Giving the user a customer id leads to configuration errors, because I don't have any stripe credentials and it's trying to talk to stripe.

To avoid this, I stubbed some methods and described my expectations about which would be called. To make this easier, I created a Customer class, which wraps an instance of Stripe::Customer and has a more concise external API.

The controller will still fail when a user doesn't have a customer_id and tries to update their credit card, but I don't know if that's possible?

hopefully resolves #91
