### PR TITLE
Make entry_limit customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Feedbin uses environment variables for configuration. Feedbin will run without a
 | DATABASE_URL             | Database connection string - postgres://USER:PASS@IP:PORT/DATABASE                 |
 | DEFAULT_URL_OPTIONS_HOST | Mailer host - feedbin.com                                                          |
 | ELASTICSEARCH_URL        | search endpoint - http://localhost:9200                                            |
+| ENTRY_LIMIT              | Maximum entries per feed. Older entries will be deleted.                           |
 | FEEDBIN_HOMEPAGE_REPO    | Git URL to a Rails engine that provides a custom homepage                          |
 | FROM_ADDRESS             | Used as a reply-to email address                                                   |
 | GAUGES_SITE_ID           | [gaug.es](http://gaug.es) analytics identifier                                     |

--- a/app/workers/entry_deleter.rb
+++ b/app/workers/entry_deleter.rb
@@ -10,7 +10,8 @@ class EntryDeleter
   end
 
   def delete_entries(feed_id)
-    entry_limit = 500
+    entry_limit = ENV['ENTRY_LIMIT'].to_i
+    entry_limit = 500 if entry_limit == 0
     entry_count = Entry.where(feed_id: feed_id).count
     if entry_count > entry_limit
       entries_to_keep = Entry.where(feed_id: feed_id).order('published DESC').limit(entry_limit).pluck('entries.id')

--- a/app/workers/entry_deleter.rb
+++ b/app/workers/entry_deleter.rb
@@ -10,8 +10,7 @@ class EntryDeleter
   end
 
   def delete_entries(feed_id)
-    entry_limit = ENV['ENTRY_LIMIT'].to_i
-    entry_limit = 500 if entry_limit == 0
+    entry_limit = ENV['ENTRY_LIMIT'] ? ENV['ENTRY_LIMIT'].to_i : 500
     entry_count = Entry.where(feed_id: feed_id).count
     if entry_count > entry_limit
       entries_to_keep = Entry.where(feed_id: feed_id).order('published DESC').limit(entry_limit).pluck('entries.id')


### PR DESCRIPTION
500 is used if `ENV['ENTRY_LIMIT']` is zero or invalid so existing installations will continue to work as usal.