### PR TITLE
OSX 10.11 font updates

### DIFF
--- a/app/assets/stylesheets/_functions.scss
+++ b/app/assets/stylesheets/_functions.scss
@@ -183,3 +183,36 @@
     }
 }
 
+@mixin generateFontFace($fontName, $fontPSPrefix, $suffixMap, $italicSuffix: "Italic") {
+	@each $weight, $suffix in $suffixMap{
+		@font-face {
+			font-family: $fontName;
+			font-weight: $weight;
+			font-style: normal;
+			src: local("#{$fontPSPrefix}-#{$suffix}");
+		}
+
+		@font-face {
+			font-family: $fontName;
+			font-weight: $weight;
+			font-style: italic;
+			src: local("#{$fontPSPrefix}-#{$suffix}#{$italicSuffix}");
+		}
+	}
+}
+
+@mixin SFFontFace {
+	$sfSuffixMap: (
+		100: "Light",
+		200: "Light",
+		300: "Light",
+		400: "Regular",
+		500: "Regular",
+		600: "Semibold",
+		700: "Bold",
+		800: "Bold",
+		900: "Heavy"
+	);
+
+	@include generateFontFace("FeedbinSanFrancisco", ".SFNSText", $sfSuffixMap);
+}

--- a/app/assets/stylesheets/_functions.scss
+++ b/app/assets/stylesheets/_functions.scss
@@ -183,36 +183,44 @@
     }
 }
 
-@mixin generateFontFace($fontName, $fontPSPrefix, $suffixMap, $italicSuffix: "Italic") {
-	@each $weight, $suffix in $suffixMap{
-		@font-face {
-			font-family: $fontName;
-			font-weight: $weight;
-			font-style: normal;
-			src: local("#{$fontPSPrefix}-#{$suffix}");
+@mixin generate-font-face($new-font-name, $font-basename, $suffix-map, $italic-suffix: "Italic") {
+	@each $weight, $suffix in $suffix-map{
+		$italic-suffix: false;
+
+		@if length($suffix) == 1 {
+			$italic-suffix: "#{$suffix}Italic";
+		} @else {
+			$italic-suffix: nth($suffix, 2);
 		}
 
 		@font-face {
-			font-family: $fontName;
+			font-family: $new-font-name;
+			font-weight: $weight;
+			font-style: normal;
+			src: local("#{$font-basename}-#{nth($suffix, 1)}");
+		}
+
+		@font-face {
+			font-family: $new-font-name;
 			font-weight: $weight;
 			font-style: italic;
-			src: local("#{$fontPSPrefix}-#{$suffix}#{$italicSuffix}");
+			src: local("#{$font-basename}-#{$italic-suffix}");
 		}
 	}
 }
 
-@mixin SFFontFace {
-	$sfSuffixMap: (
+@mixin SF-font-face {
+	$sf-suffix-map: (
 		100: "Light",
 		200: "Light",
 		300: "Light",
-		400: "Regular",
-		500: "Regular",
+		400: ("Regular", "Italic"), // "Italic", not "RegularItalic"
+		500: "Medium",
 		600: "Semibold",
 		700: "Bold",
-		800: "Bold",
+		800: "Heavy",
 		900: "Heavy"
 	);
 
-	@include generateFontFace("FeedbinSanFrancisco", ".SFNSText", $sfSuffixMap);
+	@include generate-font-face("Feedbin San Francisco", ".SFNSText", $sf-suffix-map);
 }

--- a/app/assets/stylesheets/_functions.scss
+++ b/app/assets/stylesheets/_functions.scss
@@ -183,44 +183,68 @@
     }
 }
 
-@mixin generate-font-face($new-font-name, $font-basename, $suffix-map, $italic-suffix: "Italic") {
-	@each $weight, $suffix in $suffix-map{
-		$italic-suffix: false;
+@mixin generate-font-face($new-font-name, $src-font-basename, $fonts) {
+    @each $font in $fonts {
+        $suffix: map-get($font, suffix);
+        $italic-suffix: map-get($font, suffix-italic) or "#{$suffix}Italic";
 
-		@if length($suffix) == 1 {
-			$italic-suffix: "#{$suffix}Italic";
-		} @else {
-			$italic-suffix: nth($suffix, 2);
-		}
-
-		@font-face {
-			font-family: $new-font-name;
-			font-weight: $weight;
-			font-style: normal;
-			src: local("#{$font-basename}-#{nth($suffix, 1)}");
-		}
-
-		@font-face {
-			font-family: $new-font-name;
-			font-weight: $weight;
-			font-style: italic;
-			src: local("#{$font-basename}-#{$italic-suffix}");
-		}
-	}
+        @font-face {
+            font-family: $new-font-name;
+            font-weight: map-get($font, font-weight);
+            font-style: normal;
+            src: local("#{$src-font-basename}-#{$suffix}");
+        }
+        @font-face {
+            font-family: $new-font-name;
+            font-weight: map-get($font, font-weight);
+            font-style: italic;
+            src: local("#{$src-font-basename}-#{$italic-suffix}");
+        }
+    }
 }
 
-@mixin SF-font-face {
-	$sf-suffix-map: (
-		100: "Light",
-		200: "Light",
-		300: "Light",
-		400: ("Regular", "Italic"), // "Italic", not "RegularItalic"
-		500: "Medium",
-		600: "Semibold",
-		700: "Bold",
-		800: "Heavy",
-		900: "Heavy"
-	);
+@mixin SF-UI-Text-font-face {
+    $fonts: (
+        (
+            font-weight: 100,
+            suffix: "Light"
+        ),
+        (
+            font-weight: 200,
+            suffix: "Light"
+        ),
+        (
+            font-weight: 300,
+            suffix: "Light"
+        ),
+        (
+            font-weight: 400,
+            suffix: "Regular",
+            suffix-italic: "Italic",
+        ),
+        (
+            font-weight: 500,
+            suffix: "Medium"
+        ),
+        (
+            font-weight: 600,
+            suffix: "Semibold"
+        ),
+        (
+            font-weight: 700,
+            suffix: "Bold"
+        ),
+        (
+            font-weight: 800,
+            suffix: "Heavy"
+        ),
+        (
+            font-weight: 900,
+            suffix: "Heavy"
+        )
+    );
 
-	@include generate-font-face("Feedbin San Francisco", ".SFNSText", $sf-suffix-map);
+    @include generate-font-face("Feedbin SF UI Text", ".SFNSText", $fonts);
 }
+
+@include SF-UI-Text-font-face;

--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -6,7 +6,7 @@
 Variables
 ------------------------------------------------------------------------------*/
 $toolbar-height: 41px;
-$font-stack: -apple-system, "SF UI Text", "Feedbin SF UI Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$font-stack: -apple-system, "Feedbin SF UI Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
 $feeds-toolbar-height: 52px;
 $base-button-position: 10px;
 

--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -6,7 +6,7 @@
 Variables
 ------------------------------------------------------------------------------*/
 $toolbar-height: 41px;
-$font-stack: -apple-system, "Feedbin San Francisco", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$font-stack: -apple-system, "SF UI Text", "Feedbin SF UI Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
 $feeds-toolbar-height: 52px;
 $base-button-position: 10px;
 

--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -6,7 +6,7 @@
 Variables
 ------------------------------------------------------------------------------*/
 $toolbar-height: 41px;
-$font-stack: -apple-system, "FeedbinSanFrancisco", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$font-stack: -apple-system, "Feedbin San Francisco", "Helvetica Neue", Helvetica, Arial, sans-serif;
 $feeds-toolbar-height: 52px;
 $base-button-position: 10px;
 
@@ -692,7 +692,7 @@ Grid
 HTML Elements
 ------------------------------------------------------------------------------*/
 
-@include SFFontFace;
+@include SF-font-face;
 
 body, html {
     margin: 0;

--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -6,7 +6,7 @@
 Variables
 ------------------------------------------------------------------------------*/
 $toolbar-height: 41px;
-$font-stack: -apple-system-font, ".SFNSDisplay-Regular", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$font-stack: -apple-system-font, "FeedbinSanFrancisco", "Helvetica Neue", Helvetica, Arial, sans-serif;
 $feeds-toolbar-height: 52px;
 $base-button-position: 10px;
 
@@ -691,6 +691,9 @@ Grid
 /*------------------------------------------------------------------------------
 HTML Elements
 ------------------------------------------------------------------------------*/
+
+@include SFFontFace;
+
 body, html {
     margin: 0;
     padding: 0;

--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -6,7 +6,7 @@
 Variables
 ------------------------------------------------------------------------------*/
 $toolbar-height: 41px;
-$font-stack: -apple-system-font, "FeedbinSanFrancisco", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$font-stack: -apple-system, "FeedbinSanFrancisco", "Helvetica Neue", Helvetica, Arial, sans-serif;
 $feeds-toolbar-height: 52px;
 $base-button-position: 10px;
 

--- a/config/initializers/fonts.rb
+++ b/config/initializers/fonts.rb
@@ -1,6 +1,6 @@
 Feedbin::Application.config.font_sizes = (1..10).to_a
 Feedbin::Application.config.fonts = {
-    'Helvetica Neue' => 'default',
+    'System Font'    => 'default',
     'Whitney'        => 'sans-serif-1',
     'Ideal Sans'     => 'sans-serif-2',
     'Sentinel'       => 'serif-1',


### PR DESCRIPTION
I noticed you added San Francisco to the default font stack a little while ago (rad, thanks!!). I noticed some crunchy faux bold stuff in the sidebar and did some digging around to figure out why. The problem is pretty simple, and the solution is too: instead of referencing the PostScript name of San Francisco directly, I created a new `@font-face` font that points to the correct weights and styles of San Francisco Text.

Breakdown of changes:

* Font switcher display text changed from “Helvetica Neue” to “System Font”. It’s still not entirely accurate—system standard fonts (Segoe UI, etc.) for non-OSX platforms aren’t in the stack and probably should be.
* Fleshed out San Francisco font stack to allow for more than one
weight.
* Switched San Francisco Display (`.SFNSDisplay-Regular`) to San Francisco Text (`.SFNSText-*`), as the display weight of San Francisco is only supposed to be used when font-size is 20px or greater.

Let me know if you need clarification on anything. Thanks!