### PR TITLE
Settings switch visual fixes

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -4277,7 +4277,7 @@ Settings
         }
         input[type="checkbox"] + label .slider-checkbox {
             width: 56px;
-            height: 27px;
+            height: 26px;
             display: block;
             position: absolute;
             right: 30px;
@@ -4286,9 +4286,9 @@ Settings
             background-color: #9e9e9e;
             &:before {
                 background-color: #FFF;
-                height: 23px;
-                width: 23px;
-                border-radius: 23px;
+                height: 22px;
+                width: 22px;
+                border-radius: 22px;
                 background-color: #FFF;
                 content: "";
                 top: 2px;
@@ -4303,9 +4303,9 @@ Settings
                 position: absolute;
                 display: block;
                 content: "";
-                height: 23px;
-                width: 23px;
-                border-radius: 23px;
+                height: 22px;
+                width: 22px;
+                border-radius: 22px;
                 background-color: #FFF;
                 left: 2px;
                 top: 2px;
@@ -4318,11 +4318,11 @@ Settings
         input[type="checkbox"]:checked + label .slider-checkbox {
             background-color: $selected;
             &:after {
-                left: 30px;
-                background: #FFF image-url("icon-check.svg") 4px 6px no-repeat;
+                left: 32px;
+                background: #FFF image-url("icon-check.svg") 4px 5px no-repeat;
             }
             &:before {
-                left: 30px;
+                left: 32px;
                 opacity: 0;
             }
         }


### PR DESCRIPTION
Fixed some minor visual weirdness on the settings page.

`border-radius` on odd-sized shapes gets rounded down to the nearest integer (in Google Chrome, most likely other browsers as well), so the 23px square switch was only getting an effective `border-radius` of 11px instead of 11.5px, which resulted in flat spots. Same goes with the switch container, which was 27px high.

Before and after:

![before-and-after](https://cloud.githubusercontent.com/assets/13781/8769980/e3faed16-2e5d-11e5-92ea-d7cb7e4913db.gif)
