### PR TITLE
Experimental Unread Feed Shuffling (completely unsolicited feature)

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -32,7 +32,8 @@ class EntriesController < ApplicationController
     unread_entries = @user.unread_entries.select(:entry_id).page(params[:page]).sort_preference(@user.entry_sort)
     @entries = Entry.entries_with_feed(unread_entries, @user.entry_sort).entries_list
 
-    # Shim for adjustments to unread entries
+    # Proper location for adjustments to unread entries?
+    
     case @user.entry_sort
      when 'SHUFF'
 

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -84,7 +84,7 @@ class EntriesController < ApplicationController
         end ]
 
         scores = Hash[ frontier.keys.map do |k| 
-          [k, a * (feed_used_count[k] ** growth_factor) + b * frontier_times[k]] unless frontier_times[k] == -1
+          [k, a * frontier_times[k] + b * (feed_used_count[k] ** growth_factor) ] unless frontier_times[k] == -1
         end ]
 
         result = scores.min_by { |k, v| v }[0]

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -53,7 +53,7 @@ class EntriesController < ApplicationController
       # *   e = number of previous entries from selected feed (in entries ^ growth factor)
       # *
       # * Add the first entry from the feed with the lowest score
-      # * Repeat through all unread entries
+      # * Repeat through all unread entries O(n)
 
       split_entries = {}
       @entries.map do |e| 

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -46,15 +46,15 @@ class EntriesController < ApplicationController
       # * Find the amount of entries in each feed (feed_queue_lengths): O(n) time
       # * Establish frontier of most recent entry from each feed (frontier)
       # * Find the time since publication of each item on the frontier (frontier_times)
-      # *
+      # 
       # * Produce score for each entry on frontier that is calculated as:
       # *   a*t + b*(e^g)
-      # *   
+      #    
       # *   a = adjustment factor for time since publication
       # *   t = time since publication (in hours)
       # *   b = adjustment factor for previous entries displayed
       # *   e = number of previous entries from selected feed (in entries ^ growth factor)
-      # *
+      # 
       # * Add the first entry from the feed with the lowest score
       # * Repeat through all unread entries O(n)
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -210,7 +210,7 @@ class Entry < ActiveRecord::Base
       entries = entries.order('published ASC')
     else
       entries = entries.order('published DESC')
-    end    
+    end
     entries
   end
 

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -210,7 +210,7 @@ class Entry < ActiveRecord::Base
       entries = entries.order('published ASC')
     else
       entries = entries.order('published DESC')
-    end
+    end    
     entries
   end
 

--- a/app/views/settings/settings.html.erb
+++ b/app/views/settings/settings.html.erb
@@ -17,8 +17,14 @@
                     <%= f.label('entry_sort_desc', "Newest First") %>
                 </li>
                 <li>
-                    <%= f.radio_button(:entry_sort, "ASC") %>
+                    <%= f.radio_button(:entry_sort, "ASC", 
+                        {checked: @user.entry_sort === 'ASC'}) %>
                     <%= f.label('entry_sort_asc', "Oldest First") %>
+                </li>
+                <li>
+                    <%= f.radio_button(:entry_sort, "SHUFF",
+                        { checked: @user.entry_sort == 'SHUFF'}) %>
+                    <%= f.label('entry_sort_shuff', "Shuffled") %>
                 </li>
             </ul>
 


### PR DESCRIPTION
This is kind of a little personal project that I built on top of feedbin. Let me know if this is a feature you'd like in the main branch of the project.

I've long been frustrated with RSS readers getting flooded by extremely prolific feeds (or, in some cases, extremely popular feeds). As a result, posts from smaller blogs tend to get completely lost in the shuffle amongst bigger blogs. 

My goal is to come up with a good sorting solution for RSS feeds that:

* Provides a roughly chronological view
* Logically shuffles to reduce the flooding of prolific feeds
* Is user-data independent (thus avoiding flooding from very popular feeds) 

This is a work-in-progress roughly based on A* pathfinding algorithms. It takes each set of retrieved unread entries (seemingly 100 entries) and re-sorts according to a heuristic that uses, along with adjustable constants: 

* the number of entries already included from a selected entry's feed; and
* the time since the selected entry was published

I'm still playing around with it. It may be needlessly complex... (but I think its adjustability compensates for its complexity). In practice, it's already seeming to have a pretty dramatic impact on creating a more varied unread feed.

Note - I'm not really too much a Ruby / Rails expert. Let me know if my code:

* is inserted at an appropriate point
* even remotely comports with accepted Ruby / Rails styles, conventions, and idioms

Thanks!  