### PR TITLE
Build fixes

### DIFF
--- a/doc/INSTALL-fedora.md
+++ b/doc/INSTALL-fedora.md
@@ -5,7 +5,7 @@ Feedbin Installation on Fedora
 
 Install a bunch of dependencies:
 
-    sudo yum -y install gcc gcc-c++ git libcurl-devel libxml2-devel libxslt-devel postgresql postgresql-devel rubygems ruby-devel rubygem-bundler ImageMagick-devel
+    sudo dnf install gcc gcc-c++ git libcurl-devel libxml2-devel libxslt-devel postgresql postgresql-devel rubygems ruby-devel rubygem-bundler ImageMagick-devel opencv-devel
 
 Get Feedbin:
 
@@ -30,7 +30,7 @@ After changing this file, it's probably a good idea to open a new terminal to ma
 
 Install PostgreSQL:
 
-    sudo yum -y install postgresql-server postgresql-contrib
+    sudo dnf install postgresql-server postgresql-contrib
     sudo postgresql-setup initdb
 
 Remove all authentication by changing `/var/lib/pgsql/data/pg_hba.conf` so
@@ -73,7 +73,7 @@ Setup databases:
 
 Install:
 
-    sudo yum install redis
+    sudo dnf install redis
 
 Start the service:
 

--- a/doc/INSTALL-mac.md
+++ b/doc/INSTALL-mac.md
@@ -19,14 +19,16 @@ These can be downloaded from the [Apple Developer website](https://developer.app
     echo 'if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi' >> ~/.bash_profile
     source ~/.bash_profile
 
-#### Ruby 2.1.4
+#### Ruby 2.2.3
 
-    rbenv install 2.1.4
-    rbenv global 2.1.4
+    rbenv install 2.2.3
+    rbenv global 2.2.3
 
 #### Bundler
 
     gem install bundler
+
+You may need to open a new terminal to make the `bundle` command available in your `PATH`.
 
 #### Postgres 9.2.4
 


### PR DESCRIPTION
I'm getting this error:

    $ bundle install
    Fetching source index from https://rubygems.org/
    Could not find fog-aliyun-0.0.10 in any of the sources

It looks like that was previously published, then removed:

<https://rubygems.org/gems/fog-aliyun/versions/0.0.10>

I updated Gemfile.lock, and also updated the Fedora instructions (`yum` was replaced with `dnf` a few releases ago, and we need to need opencv-devel for one of the gems now).