### PR TITLE
Add OAuth2 authentication to API endpoints with Doorkeeper.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ group :development do
   gem 'spring'
   gem 'benchmark-ips'
   gem 'xipio'
+  # gem 'binding_of_caller'
+  # gem 'pry-rails'
 end
 
 group :development, :test do
@@ -80,6 +82,7 @@ gem 'ruby-opencv', require: false
 gem 'rails-deprecated_sanitizer'
 gem 'responders', '~> 2.0'
 gem 'dotenv-rails'
+gem 'doorkeeper'
 
 # Sidekiq
 gem 'sidekiq'

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,6 @@ group :development do
   gem 'spring'
   gem 'benchmark-ips'
   gem 'xipio'
-  # gem 'binding_of_caller'
-  # gem 'pry-rails'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
     dalli (2.7.5)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    doorkeeper (3.1.0)
+      railties (>= 3.2)
     dotenv (2.1.0)
     dotenv-rails (2.1.0)
       dotenv (= 2.1.0)
@@ -520,6 +522,7 @@ DEPENDENCIES
   coffee-rails
   connection_pool
   dalli
+  doorkeeper
   dotenv-rails
   evernote_oauth
   factory_girl_rails

--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -1187,6 +1187,26 @@ table {
 
 }
 
+.applications-list {
+    @extend .sharing-services;
+
+    .application-header {
+        @include settings-row;
+    }
+
+    .application-title {
+        @extend .service-title;
+        padding: 0;
+    }
+
+    .application-revoke {
+        position: absolute;
+        right: 15px;
+        top: 16px;
+        color: red;
+    }
+}
+
 .inset {
     background-color: $inset-bg-color;
     border-radius: 8px;

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -23,6 +23,11 @@ class SettingsController < ApplicationController
     @classes = user_classes
   end
 
+  def applications
+    @user = current_user
+    @applications = Doorkeeper::Application.authorized_for(@user)
+  end
+
   def feeds
     @user = current_user
     @subscriptions = @user.subscriptions.select('subscriptions.*, feeds.title AS original_title, feeds.last_published_entry AS last_published_entry, feeds.feed_url, feeds.site_url, feeds.host').joins("INNER JOIN feeds ON subscriptions.feed_id = feeds.id AND subscriptions.user_id = #{@user.id}").includes(:feed)

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -13,7 +13,6 @@ module SessionsHelper
   def current_user
     @current_user ||= begin
       if request.subdomain == "api"
-
         if valid_doorkeeper_token?
           User.find(doorkeeper_token.resource_owner_id)
         else 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -13,8 +13,13 @@ module SessionsHelper
   def current_user
     @current_user ||= begin
       if request.subdomain == "api"
-        authenticate_with_http_basic do |username, password|
-          User.where('lower(email) = ?', username.try(:downcase)).take.try(:authenticate, password)
+
+        if valid_doorkeeper_token?
+          User.find(doorkeeper_token.resource_owner_id)
+        else 
+          authenticate_with_http_basic do |username, password|
+            User.where('lower(email) = ?', username.try(:downcase)).take.try(:authenticate, password)
+          end
         end
       else
         User.find_by_auth_token(cookies.signed[:auth_token]) if cookies.signed[:auth_token]

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -1,0 +1,42 @@
+<% @class = 'login' %>
+
+<div class="login-wrap">
+  <a href="/" class="logo hide-text">Feedbin</a>
+
+  <div class="box">
+    <h3 class="box-header">
+      <%= raw t('.prompt', client_name: "<strong class=\"text-info\">#{ @pre_auth.client.name }</strong>") %>
+    </h3>
+
+    <% if @pre_auth.scopes.count > 0 %>
+      <div id="oauth-permissions">
+        <p><%= t('.able_to') %>:</p>
+
+        <ul class="text-info">
+          <% @pre_auth.scopes.each do |scope| %>
+            <li><%= t scope, scope: [:doorkeeper, :scopes] %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="actions">
+      <%= form_tag oauth_authorization_path, method: :post do %>
+        <%= hidden_field_tag :client_id, @pre_auth.client.uid %>
+        <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
+        <%= hidden_field_tag :state, @pre_auth.state %>
+        <%= hidden_field_tag :response_type, @pre_auth.response_type %>
+        <%= hidden_field_tag :scope, @pre_auth.scope %>
+        <%= submit_tag t('doorkeeper.authorizations.buttons.authorize'), class: "btn btn-success btn-lg btn-block" %>
+      <% end %>
+      <%= form_tag oauth_authorization_path, method: :delete do %>
+        <%= hidden_field_tag :client_id, @pre_auth.client.uid %>
+        <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
+        <%= hidden_field_tag :state, @pre_auth.state %>
+        <%= hidden_field_tag :response_type, @pre_auth.response_type %>
+        <%= hidden_field_tag :scope, @pre_auth.scope %>
+        <%= submit_tag t('doorkeeper.authorizations.buttons.deny'), class: "btn btn-danger btn-lg btn-block" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/settings/applications.html.erb
+++ b/app/views/settings/applications.html.erb
@@ -1,0 +1,31 @@
+<div class="settings-content-inner">
+    <div class="settings-outer">
+        <h2>Applications</h2>
+    </div>
+
+    <div class="inset">
+        <div class="inset-content">
+            <h4 class="group-header">Active Applications</h4>
+        </div>
+
+        <ul class="applications-list">
+        <% if @applications.any? %>
+            <% @applications.each do |application| %>
+            <li>
+                <div class="application-header">
+                    <p class="application-title"><%= application.name %></p>
+                </div>
+                <%= link_to 'Revoke', oauth_authorized_application_path(application), class: 'button button-cancel application-revoke show-service-options', method: :delete, data: { confirm: "Are you sure you want to revoke access to #{application.name}?" } %>
+            </li>
+            <% end %>
+        <% else %>
+            <li>
+                <div class="application-header">
+                    <p class="application-title">No Applications Found</p>
+                </div>
+            </li>
+        <% end %>
+
+        </ul>
+    </div>
+</div>

--- a/app/views/shared/_app_settings.html.erb
+++ b/app/views/shared/_app_settings.html.erb
@@ -14,6 +14,9 @@
             <ul class="segmented">
                 <li><%= link_to 'Actions', actions_path, class: "no-border" %></li>
                 <li><%= link_to 'Sharing', sharing_services_path %></li>
+                <% if Doorkeeper::Application.authorized_for(@user).length > 1 %>
+                    <li><%= link_to 'Applications', settings_applications_path %></li>
+                <% end %>
             </ul>
             <ul class="segmented">
                 <li><%= link_to 'Account', settings_account_path, class: "no-border" %></li>

--- a/app/views/shared/_settings_nav.html.erb
+++ b/app/views/shared/_settings_nav.html.erb
@@ -7,6 +7,7 @@
     <li><%= link_to 'Feeds', settings_feeds_path, class: is_active?(['settings', 'subscriptions'], ['feeds', 'edit']) %></li>
     <li><%= link_to 'Actions', actions_path, class: is_active?('actions', ['index', 'new', 'edit']) %></li>
     <li><%= link_to 'Sharing', sharing_services_path, class: is_active?('sharing_services', 'index') %></li>
+    <li><%= link_to 'Applications', settings_applications_path, class: is_active?('applications', 'index') %></li>
     <li><%= link_to 'Account', settings_account_path, class: is_active?('settings', 'account') %></li>
     <% if ENV['STRIPE_API_KEY'] %>
         <li><%= link_to 'Billing', settings_billing_path, class: is_active?('settings', 'billing') %></li>

--- a/app/views/shared/_settings_nav.html.erb
+++ b/app/views/shared/_settings_nav.html.erb
@@ -7,7 +7,7 @@
     <li><%= link_to 'Feeds', settings_feeds_path, class: is_active?(['settings', 'subscriptions'], ['feeds', 'edit']) %></li>
     <li><%= link_to 'Actions', actions_path, class: is_active?('actions', ['index', 'new', 'edit']) %></li>
     <li><%= link_to 'Sharing', sharing_services_path, class: is_active?('sharing_services', 'index') %></li>
-    <li><%= link_to 'Applications', settings_applications_path, class: is_active?('applications', 'index') %></li>
+    <li><%= link_to 'Applications', settings_applications_path, class: is_active?('settings', 'applications') %></li>
     <li><%= link_to 'Account', settings_account_path, class: is_active?('settings', 'account') %></li>
     <% if ENV['STRIPE_API_KEY'] %>
         <li><%= link_to 'Billing', settings_billing_path, class: is_active?('settings', 'billing') %></li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,5 +48,14 @@ module Feedbin
 
     config.eager_load_paths += ["#{config.root}/app/image_pipeline"]
 
+    config.to_prepare do 
+      Doorkeeper::AuthorizationsController.layout 'application'
+      Doorkeeper::AuthorizationsController.add_flash_types :analytics_event
+
+      Doorkeeper::AuthorizedApplicationsController.before_action :only => [:index] do
+        redirect_to(settings_applications_path)        
+      end
+    end
+
   end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,12 +1,13 @@
+include SessionsHelper
+
 Doorkeeper.configure do
   # Change the ORM that doorkeeper will use (needs plugins)
   orm :active_record
 
   # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
-    # Put your resource owner authentication logic here.
-    # Example implementation:
-    #   User.find_by_id(session[:user_id]) || redirect_to(new_user_session_url)
+    authorize
+    current_user
   end
 
   # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,18 +11,19 @@ Doorkeeper.configure do
   end
 
   # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
-  # admin_authenticator do
-  #   # Put your admin authentication logic here.
-  #   # Example implementation:
-  #   Admin.find_by_id(session[:admin_id]) || redirect_to(new_admin_session_url)
-  # end
+  admin_authenticator do
+    authorize
+    if signed_in? && !current_user.admin
+      render :nothing => true, :status => :unauthorized
+    end
+  end
 
   # Authorization Code expiration time (default 10 minutes).
   # authorization_code_expires_in 10.minutes
 
   # Access token expiration time (default 2 hours).
   # If you want to disable expiration, set this to nil.
-  # access_token_expires_in 2.hours
+  access_token_expires_in nil
 
   # Assign a custom TTL for implicit grants.
   # custom_access_token_expires_in do |oauth_client|

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,106 @@
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use (needs plugins)
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+    # Put your resource owner authentication logic here.
+    # Example implementation:
+    #   User.find_by_id(session[:user_id]) || redirect_to(new_user_session_url)
+  end
+
+  # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
+  # admin_authenticator do
+  #   # Put your admin authentication logic here.
+  #   # Example implementation:
+  #   Admin.find_by_id(session[:admin_id]) || redirect_to(new_admin_session_url)
+  # end
+
+  # Authorization Code expiration time (default 10 minutes).
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default 2 hours).
+  # If you want to disable expiration, set this to nil.
+  # access_token_expires_in 2.hours
+
+  # Assign a custom TTL for implicit grants.
+  # custom_access_token_expires_in do |oauth_client|
+  #   oauth_client.application.additional_settings.implicit_oauth_expiration
+  # end
+
+  # Use a custom class for generating the access token.
+  # https://github.com/doorkeeper-gem/doorkeeper#custom-access-token-generator
+  # access_token_generator "::Doorkeeper::JWT"
+
+  # Reuse access token for the same resource owner within an application (disabled by default)
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  # reuse_access_token
+
+  # Issue access tokens with refresh token (disabled by default)
+  # use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
+  # a registered application
+  # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
+  # enable_application_owner :confirmation => false
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://github.com/doorkeeper-gem/doorkeeper/wiki/Using-Scopes
+  # default_scopes  :public
+  # optional_scopes :write, :update
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Change the native redirect uri for client apps
+  # When clients register with the following redirect uri, they won't be redirected to any server and the authorization code will be displayed within the provider
+  # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL
+  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
+  #
+  # native_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  #
+  # force_ssl_in_redirect_uri !Rails.env.development?
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables authorization_code and
+  # client_credentials.
+  #
+  # implicit and password grant flows have risks that you should understand
+  # before enabling:
+  #   http://tools.ietf.org/html/rfc6819#section-4.4.2
+  #   http://tools.ietf.org/html/rfc6819#section-4.4.3
+  #
+  # grant_flows %w(authorization_code client_credentials)
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with a trusted application.
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # WWW-Authenticate Realm (default "Doorkeeper").
+  # realm "Doorkeeper"
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,123 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Name'
+        redirect_uri: 'Redirect URI'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+              secured_uri: 'must be an HTTPS/SSL URI.'
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Are you sure?'
+      buttons:
+        edit: 'Edit'
+        destroy: 'Destroy'
+        submit: 'Submit'
+        cancel: 'Cancel'
+        authorize: 'Authorize'
+      form:
+        error: 'Whoops! Check your form for possible errors'
+      help:
+        redirect_uri: 'Use one line per URI'
+        native_redirect_uri: 'Use %{native_redirect_uri} for local tests'
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
+      edit:
+        title: 'Edit application'
+      index:
+        title: 'Your applications'
+        new: 'New Application'
+        name: 'Name'
+        callback_url: 'Callback URL'
+      new:
+        title: 'New Application'
+      show:
+        title: 'Application: %{name}'
+        application_id: 'Application Id'
+        secret: 'Secret'
+        scopes: 'Scopes'
+        callback_urls: 'Callback urls'
+        actions: 'Actions'
+
+    authorizations:
+      buttons:
+        authorize: 'Authorize'
+        deny: 'Deny'
+      error:
+        title: 'An error has occurred'
+      new:
+        title: 'Authorization required'
+        prompt: 'Authorize %{client_name} to use your account?'
+        able_to: 'This application will be able to'
+      show:
+        title: 'Authorization code'
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Are you sure?'
+      buttons:
+        revoke: 'Revoke'
+      index:
+        title: 'Your authorized applications'
+        application: 'Application'
+        created_at: 'Created At'
+        date_format: '%Y-%m-%d %H:%M:%S'
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+        invalid_redirect_uri: 'The redirect uri included is not valid.'
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        #configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfiged.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        # Password Access token errors
+        invalid_resource_owner: 'The provided resource owner credentials are not valid, or resource owner cannot be found'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'
+
+    layouts:
+      admin:
+        nav:
+          oauth2_provider: 'OAuth2 Provider'
+          applications: 'Applications'
+      application:
+        title: 'OAuth authorization required'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Feedbin::Application.routes.draw do
 
+  use_doorkeeper
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,7 @@ Feedbin::Application.routes.draw do
     get :feeds
     get :help
     get :appearance
+    get :applications
     post :update_credit_card
     post :mark_favicon_complete
     post :update_plan

--- a/db/migrate/20160131175812_create_doorkeeper_tables.rb
+++ b/db/migrate/20160131175812_create_doorkeeper_tables.rb
@@ -1,0 +1,50 @@
+class CreateDoorkeeperTables < ActiveRecord::Migration
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,         null: false
+      t.string  :uid,          null: false
+      t.string  :secret,       null: false
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      t.timestamps
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.integer  :resource_owner_id, null: false
+      t.integer  :application_id,    null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+
+    create_table :oauth_access_tokens do |t|
+      t.integer  :resource_owner_id
+      t.integer  :application_id
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text     :token,             null: false
+      t.string   :token,             null: false
+
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.datetime :revoked_at
+      t.datetime :created_at,        null: false
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+    add_index :oauth_access_tokens, :resource_owner_id
+    add_index :oauth_access_tokens, :refresh_token, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,12 +2,16 @@
 -- PostgreSQL database dump
 --
 
+-- Dumped from database version 9.5.0
+-- Dumped by pg_dump version 9.5.0
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
 SET client_min_messages = warning;
+SET row_security = off;
 
 --
 -- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
@@ -58,7 +62,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: actions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: actions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE actions (
@@ -97,7 +101,7 @@ ALTER SEQUENCE actions_id_seq OWNED BY actions.id;
 
 
 --
--- Name: billing_events; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: billing_events; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE billing_events (
@@ -132,7 +136,7 @@ ALTER SEQUENCE billing_events_id_seq OWNED BY billing_events.id;
 
 
 --
--- Name: coupons; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: coupons; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE coupons (
@@ -166,7 +170,7 @@ ALTER SEQUENCE coupons_id_seq OWNED BY coupons.id;
 
 
 --
--- Name: deleted_users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: deleted_users; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE deleted_users (
@@ -198,7 +202,7 @@ ALTER SEQUENCE deleted_users_id_seq OWNED BY deleted_users.id;
 
 
 --
--- Name: devices; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: devices; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE devices (
@@ -234,7 +238,7 @@ ALTER SEQUENCE devices_id_seq OWNED BY devices.id;
 
 
 --
--- Name: entries; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: entries; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE entries (
@@ -282,7 +286,7 @@ ALTER SEQUENCE entries_id_seq OWNED BY entries.id;
 
 
 --
--- Name: favicons; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: favicons; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE favicons (
@@ -314,7 +318,7 @@ ALTER SEQUENCE favicons_id_seq OWNED BY favicons.id;
 
 
 --
--- Name: feed_stats; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: feed_stats; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE feed_stats (
@@ -347,7 +351,7 @@ ALTER SEQUENCE feed_stats_id_seq OWNED BY feed_stats.id;
 
 
 --
--- Name: feeds; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: feeds; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE feeds (
@@ -389,7 +393,7 @@ ALTER SEQUENCE feeds_id_seq OWNED BY feeds.id;
 
 
 --
--- Name: import_items; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: import_items; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE import_items (
@@ -422,7 +426,7 @@ ALTER SEQUENCE import_items_id_seq OWNED BY import_items.id;
 
 
 --
--- Name: imports; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: imports; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE imports (
@@ -455,7 +459,7 @@ ALTER SEQUENCE imports_id_seq OWNED BY imports.id;
 
 
 --
--- Name: in_app_purchases; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: in_app_purchases; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE in_app_purchases (
@@ -490,7 +494,114 @@ ALTER SEQUENCE in_app_purchases_id_seq OWNED BY in_app_purchases.id;
 
 
 --
--- Name: plans; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_grants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE oauth_access_grants (
+    id integer NOT NULL,
+    resource_owner_id integer NOT NULL,
+    application_id integer NOT NULL,
+    token character varying NOT NULL,
+    expires_in integer NOT NULL,
+    redirect_uri text NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    revoked_at timestamp without time zone,
+    scopes character varying
+);
+
+
+--
+-- Name: oauth_access_grants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE oauth_access_grants_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: oauth_access_grants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE oauth_access_grants_id_seq OWNED BY oauth_access_grants.id;
+
+
+--
+-- Name: oauth_access_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE oauth_access_tokens (
+    id integer NOT NULL,
+    resource_owner_id integer,
+    application_id integer,
+    token character varying NOT NULL,
+    refresh_token character varying,
+    expires_in integer,
+    revoked_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    scopes character varying
+);
+
+
+--
+-- Name: oauth_access_tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE oauth_access_tokens_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: oauth_access_tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE oauth_access_tokens_id_seq OWNED BY oauth_access_tokens.id;
+
+
+--
+-- Name: oauth_applications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE oauth_applications (
+    id integer NOT NULL,
+    name character varying NOT NULL,
+    uid character varying NOT NULL,
+    secret character varying NOT NULL,
+    redirect_uri text NOT NULL,
+    scopes character varying DEFAULT ''::character varying NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: oauth_applications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE oauth_applications_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: oauth_applications_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE oauth_applications_id_seq OWNED BY oauth_applications.id;
+
+
+--
+-- Name: plans; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE plans (
@@ -524,7 +635,7 @@ ALTER SEQUENCE plans_id_seq OWNED BY plans.id;
 
 
 --
--- Name: recently_read_entries; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: recently_read_entries; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE recently_read_entries (
@@ -556,7 +667,7 @@ ALTER SEQUENCE recently_read_entries_id_seq OWNED BY recently_read_entries.id;
 
 
 --
--- Name: saved_searches; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: saved_searches; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE saved_searches (
@@ -589,7 +700,7 @@ ALTER SEQUENCE saved_searches_id_seq OWNED BY saved_searches.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE schema_migrations (
@@ -598,7 +709,7 @@ CREATE TABLE schema_migrations (
 
 
 --
--- Name: sharing_services; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: sharing_services; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE sharing_services (
@@ -631,7 +742,7 @@ ALTER SEQUENCE sharing_services_id_seq OWNED BY sharing_services.id;
 
 
 --
--- Name: starred_entries; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: starred_entries; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE starred_entries (
@@ -666,7 +777,7 @@ ALTER SEQUENCE starred_entries_id_seq OWNED BY starred_entries.id;
 
 
 --
--- Name: subscriptions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE subscriptions (
@@ -704,7 +815,7 @@ ALTER SEQUENCE subscriptions_id_seq OWNED BY subscriptions.id;
 
 
 --
--- Name: suggested_categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: suggested_categories; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE suggested_categories (
@@ -735,7 +846,7 @@ ALTER SEQUENCE suggested_categories_id_seq OWNED BY suggested_categories.id;
 
 
 --
--- Name: suggested_feeds; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: suggested_feeds; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE suggested_feeds (
@@ -767,7 +878,7 @@ ALTER SEQUENCE suggested_feeds_id_seq OWNED BY suggested_feeds.id;
 
 
 --
--- Name: supported_sharing_services; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: supported_sharing_services; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE supported_sharing_services (
@@ -801,7 +912,7 @@ ALTER SEQUENCE supported_sharing_services_id_seq OWNED BY supported_sharing_serv
 
 
 --
--- Name: taggings; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: taggings; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE taggings (
@@ -834,7 +945,7 @@ ALTER SEQUENCE taggings_id_seq OWNED BY taggings.id;
 
 
 --
--- Name: tags; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: tags; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE tags (
@@ -865,7 +976,7 @@ ALTER SEQUENCE tags_id_seq OWNED BY tags.id;
 
 
 --
--- Name: unread_entries; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: unread_entries; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE unread_entries (
@@ -880,7 +991,7 @@ CREATE TABLE unread_entries (
 
 
 --
--- Name: updated_entries; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: updated_entries; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE updated_entries (
@@ -915,7 +1026,7 @@ ALTER SEQUENCE updated_entries_id_seq OWNED BY updated_entries.id;
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+-- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE users (
@@ -1048,6 +1159,27 @@ ALTER TABLE ONLY in_app_purchases ALTER COLUMN id SET DEFAULT nextval('in_app_pu
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY oauth_access_grants ALTER COLUMN id SET DEFAULT nextval('oauth_access_grants_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY oauth_access_tokens ALTER COLUMN id SET DEFAULT nextval('oauth_access_tokens_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY oauth_applications ALTER COLUMN id SET DEFAULT nextval('oauth_applications_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY plans ALTER COLUMN id SET DEFAULT nextval('plans_id_seq'::regclass);
 
 
@@ -1136,7 +1268,7 @@ ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regcl
 
 
 --
--- Name: actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY actions
@@ -1144,7 +1276,7 @@ ALTER TABLE ONLY actions
 
 
 --
--- Name: billing_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: billing_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY billing_events
@@ -1152,7 +1284,7 @@ ALTER TABLE ONLY billing_events
 
 
 --
--- Name: coupons_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: coupons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY coupons
@@ -1160,7 +1292,7 @@ ALTER TABLE ONLY coupons
 
 
 --
--- Name: deleted_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: deleted_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY deleted_users
@@ -1168,7 +1300,7 @@ ALTER TABLE ONLY deleted_users
 
 
 --
--- Name: devices_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: devices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY devices
@@ -1176,7 +1308,7 @@ ALTER TABLE ONLY devices
 
 
 --
--- Name: entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY entries
@@ -1184,7 +1316,7 @@ ALTER TABLE ONLY entries
 
 
 --
--- Name: favicons_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: favicons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY favicons
@@ -1192,7 +1324,7 @@ ALTER TABLE ONLY favicons
 
 
 --
--- Name: feed_stats_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: feed_stats_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY feed_stats
@@ -1200,7 +1332,7 @@ ALTER TABLE ONLY feed_stats
 
 
 --
--- Name: feeds_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: feeds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY feeds
@@ -1208,7 +1340,7 @@ ALTER TABLE ONLY feeds
 
 
 --
--- Name: import_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: import_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY import_items
@@ -1216,7 +1348,7 @@ ALTER TABLE ONLY import_items
 
 
 --
--- Name: imports_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: imports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY imports
@@ -1224,7 +1356,7 @@ ALTER TABLE ONLY imports
 
 
 --
--- Name: in_app_purchases_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: in_app_purchases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY in_app_purchases
@@ -1232,7 +1364,31 @@ ALTER TABLE ONLY in_app_purchases
 
 
 --
--- Name: plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: oauth_access_grants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY oauth_access_grants
+    ADD CONSTRAINT oauth_access_grants_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oauth_access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY oauth_access_tokens
+    ADD CONSTRAINT oauth_access_tokens_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: oauth_applications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY oauth_applications
+    ADD CONSTRAINT oauth_applications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY plans
@@ -1240,7 +1396,7 @@ ALTER TABLE ONLY plans
 
 
 --
--- Name: recently_read_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: recently_read_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY recently_read_entries
@@ -1248,7 +1404,7 @@ ALTER TABLE ONLY recently_read_entries
 
 
 --
--- Name: saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: saved_searches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY saved_searches
@@ -1256,7 +1412,7 @@ ALTER TABLE ONLY saved_searches
 
 
 --
--- Name: sharing_services_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: sharing_services_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY sharing_services
@@ -1264,7 +1420,7 @@ ALTER TABLE ONLY sharing_services
 
 
 --
--- Name: starred_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: starred_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY starred_entries
@@ -1272,7 +1428,7 @@ ALTER TABLE ONLY starred_entries
 
 
 --
--- Name: subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY subscriptions
@@ -1280,7 +1436,7 @@ ALTER TABLE ONLY subscriptions
 
 
 --
--- Name: suggested_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: suggested_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY suggested_categories
@@ -1288,7 +1444,7 @@ ALTER TABLE ONLY suggested_categories
 
 
 --
--- Name: suggested_feeds_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: suggested_feeds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY suggested_feeds
@@ -1296,7 +1452,7 @@ ALTER TABLE ONLY suggested_feeds
 
 
 --
--- Name: supported_sharing_services_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: supported_sharing_services_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY supported_sharing_services
@@ -1304,7 +1460,7 @@ ALTER TABLE ONLY supported_sharing_services
 
 
 --
--- Name: taggings_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: taggings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY taggings
@@ -1312,7 +1468,7 @@ ALTER TABLE ONLY taggings
 
 
 --
--- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY tags
@@ -1320,7 +1476,7 @@ ALTER TABLE ONLY tags
 
 
 --
--- Name: updated_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: updated_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY updated_entries
@@ -1328,7 +1484,7 @@ ALTER TABLE ONLY updated_entries
 
 
 --
--- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+-- Name: users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY users
@@ -1336,455 +1492,490 @@ ALTER TABLE ONLY users
 
 
 --
--- Name: index_actions_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_actions_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_actions_on_user_id ON actions USING btree (user_id);
 
 
 --
--- Name: index_billing_events_on_billable_id_and_billable_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_billing_events_on_billable_id_and_billable_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_billing_events_on_billable_id_and_billable_type ON billing_events USING btree (billable_id, billable_type);
 
 
 --
--- Name: index_billing_events_on_event_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_billing_events_on_event_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_billing_events_on_event_id ON billing_events USING btree (event_id);
 
 
 --
--- Name: index_coupons_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_coupons_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_coupons_on_user_id ON coupons USING btree (user_id);
 
 
 --
--- Name: index_deleted_users_on_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_deleted_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_deleted_users_on_email ON deleted_users USING btree (email);
 
 
 --
--- Name: index_devices_on_lower_tokens; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_devices_on_lower_tokens; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_devices_on_lower_tokens ON devices USING btree (lower(token));
 
 
 --
--- Name: index_devices_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_devices_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_devices_on_user_id ON devices USING btree (user_id);
 
 
 --
--- Name: index_entries_on_feed_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_entries_on_feed_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_entries_on_feed_id ON entries USING btree (feed_id);
 
 
 --
--- Name: index_entries_on_public_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_entries_on_public_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_entries_on_public_id ON entries USING btree (public_id);
 
 
 --
--- Name: index_favicons_on_host; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_favicons_on_host; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_favicons_on_host ON favicons USING btree (host);
 
 
 --
--- Name: index_feed_stats_on_feed_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_feed_stats_on_feed_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_feed_stats_on_feed_id ON feed_stats USING btree (feed_id);
 
 
 --
--- Name: index_feed_stats_on_feed_id_and_day; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_feed_stats_on_feed_id_and_day; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_feed_stats_on_feed_id_and_day ON feed_stats USING btree (feed_id, day);
 
 
 --
--- Name: index_feeds_on_feed_type; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_feeds_on_feed_type; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_feeds_on_feed_type ON feeds USING btree (feed_type);
 
 
 --
--- Name: index_feeds_on_feed_url; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_feeds_on_feed_url; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_feeds_on_feed_url ON feeds USING btree (feed_url);
 
 
 --
--- Name: index_feeds_on_host; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_feeds_on_host; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_feeds_on_host ON feeds USING btree (host);
 
 
 --
--- Name: index_feeds_on_last_published_entry; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_feeds_on_last_published_entry; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_feeds_on_last_published_entry ON feeds USING btree (last_published_entry);
 
 
 --
--- Name: index_import_items_on_import_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_import_items_on_import_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_import_items_on_import_id ON import_items USING btree (import_id);
 
 
 --
--- Name: index_in_app_purchases_on_transaction_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_in_app_purchases_on_transaction_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_in_app_purchases_on_transaction_id ON in_app_purchases USING btree (transaction_id);
 
 
 --
--- Name: index_in_app_purchases_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_in_app_purchases_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_in_app_purchases_on_user_id ON in_app_purchases USING btree (user_id);
 
 
 --
--- Name: index_recently_read_entries_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_oauth_access_grants_on_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_oauth_access_grants_on_token ON oauth_access_grants USING btree (token);
+
+
+--
+-- Name: index_oauth_access_tokens_on_refresh_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens USING btree (refresh_token);
+
+
+--
+-- Name: index_oauth_access_tokens_on_resource_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_oauth_access_tokens_on_resource_owner_id ON oauth_access_tokens USING btree (resource_owner_id);
+
+
+--
+-- Name: index_oauth_access_tokens_on_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_oauth_access_tokens_on_token ON oauth_access_tokens USING btree (token);
+
+
+--
+-- Name: index_oauth_applications_on_uid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_oauth_applications_on_uid ON oauth_applications USING btree (uid);
+
+
+--
+-- Name: index_recently_read_entries_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recently_read_entries_on_created_at ON recently_read_entries USING btree (created_at);
 
 
 --
--- Name: index_recently_read_entries_on_entry_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recently_read_entries_on_entry_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recently_read_entries_on_entry_id ON recently_read_entries USING btree (entry_id);
 
 
 --
--- Name: index_recently_read_entries_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recently_read_entries_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_recently_read_entries_on_user_id ON recently_read_entries USING btree (user_id);
 
 
 --
--- Name: index_recently_read_entries_on_user_id_and_entry_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_recently_read_entries_on_user_id_and_entry_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_recently_read_entries_on_user_id_and_entry_id ON recently_read_entries USING btree (user_id, entry_id);
 
 
 --
--- Name: index_saved_searches_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_saved_searches_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_saved_searches_on_user_id ON saved_searches USING btree (user_id);
 
 
 --
--- Name: index_sharing_services_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_sharing_services_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_sharing_services_on_user_id ON sharing_services USING btree (user_id);
 
 
 --
--- Name: index_starred_entries_on_entry_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_starred_entries_on_entry_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_starred_entries_on_entry_id ON starred_entries USING btree (entry_id);
 
 
 --
--- Name: index_starred_entries_on_feed_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_starred_entries_on_feed_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_starred_entries_on_feed_id ON starred_entries USING btree (feed_id);
 
 
 --
--- Name: index_starred_entries_on_published; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_starred_entries_on_published; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_starred_entries_on_published ON starred_entries USING btree (published);
 
 
 --
--- Name: index_starred_entries_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_starred_entries_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_starred_entries_on_user_id ON starred_entries USING btree (user_id);
 
 
 --
--- Name: index_starred_entries_on_user_id_and_entry_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_starred_entries_on_user_id_and_entry_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_starred_entries_on_user_id_and_entry_id ON starred_entries USING btree (user_id, entry_id);
 
 
 --
--- Name: index_subscriptions_on_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subscriptions_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subscriptions_on_created_at ON subscriptions USING btree (created_at);
 
 
 --
--- Name: index_subscriptions_on_feed_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subscriptions_on_feed_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subscriptions_on_feed_id ON subscriptions USING btree (feed_id);
 
 
 --
--- Name: index_subscriptions_on_feed_id_and_active_and_muted; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subscriptions_on_feed_id_and_active_and_muted; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subscriptions_on_feed_id_and_active_and_muted ON subscriptions USING btree (feed_id, active, muted);
 
 
 --
--- Name: index_subscriptions_on_updates; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subscriptions_on_updates; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subscriptions_on_updates ON subscriptions USING btree (feed_id, active, muted, show_updates);
 
 
 --
--- Name: index_subscriptions_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subscriptions_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_subscriptions_on_user_id ON subscriptions USING btree (user_id);
 
 
 --
--- Name: index_subscriptions_on_user_id_and_feed_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_subscriptions_on_user_id_and_feed_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_subscriptions_on_user_id_and_feed_id ON subscriptions USING btree (user_id, feed_id);
 
 
 --
--- Name: index_suggested_feeds_on_feed_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_suggested_feeds_on_feed_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_suggested_feeds_on_feed_id ON suggested_feeds USING btree (feed_id);
 
 
 --
--- Name: index_suggested_feeds_on_suggested_category_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_suggested_feeds_on_suggested_category_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_suggested_feeds_on_suggested_category_id ON suggested_feeds USING btree (suggested_category_id);
 
 
 --
--- Name: index_supported_sharing_services_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_supported_sharing_services_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_supported_sharing_services_on_user_id ON supported_sharing_services USING btree (user_id);
 
 
 --
--- Name: index_supported_sharing_services_on_user_id_and_service_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_supported_sharing_services_on_user_id_and_service_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_supported_sharing_services_on_user_id_and_service_id ON supported_sharing_services USING btree (user_id, service_id);
 
 
 --
--- Name: index_taggings_on_tag_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_taggings_on_tag_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_taggings_on_tag_id ON taggings USING btree (tag_id);
 
 
 --
--- Name: index_taggings_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_taggings_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_taggings_on_user_id ON taggings USING btree (user_id);
 
 
 --
--- Name: index_taggings_on_user_id_and_feed_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_taggings_on_user_id_and_feed_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_taggings_on_user_id_and_feed_id ON taggings USING btree (user_id, feed_id);
 
 
 --
--- Name: index_taggings_on_user_id_and_tag_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_taggings_on_user_id_and_tag_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_taggings_on_user_id_and_tag_id ON taggings USING btree (user_id, tag_id);
 
 
 --
--- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_tags_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_tags_on_name ON tags USING btree (name);
 
 
 --
--- Name: index_unread_entries_on_entry_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_unread_entries_on_entry_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_unread_entries_on_entry_id ON unread_entries USING btree (entry_id);
 
 
 --
--- Name: index_unread_entries_on_feed_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_unread_entries_on_feed_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_unread_entries_on_feed_id ON unread_entries USING btree (feed_id);
 
 
 --
--- Name: index_unread_entries_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_unread_entries_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_unread_entries_on_user_id ON unread_entries USING btree (user_id);
 
 
 --
--- Name: index_unread_entries_on_user_id_and_created_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_unread_entries_on_user_id_and_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_unread_entries_on_user_id_and_created_at ON unread_entries USING btree (user_id, created_at);
 
 
 --
--- Name: index_unread_entries_on_user_id_and_entry_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_unread_entries_on_user_id_and_entry_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_unread_entries_on_user_id_and_entry_id ON unread_entries USING btree (user_id, entry_id);
 
 
 --
--- Name: index_unread_entries_on_user_id_and_feed_id_and_published; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_unread_entries_on_user_id_and_feed_id_and_published; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_unread_entries_on_user_id_and_feed_id_and_published ON unread_entries USING btree (user_id, feed_id, published);
 
 
 --
--- Name: index_unread_entries_on_user_id_and_published; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_unread_entries_on_user_id_and_published; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_unread_entries_on_user_id_and_published ON unread_entries USING btree (user_id, published);
 
 
 --
--- Name: index_updated_entries_on_entry_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_updated_entries_on_entry_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_updated_entries_on_entry_id ON updated_entries USING btree (entry_id);
 
 
 --
--- Name: index_updated_entries_on_feed_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_updated_entries_on_feed_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_updated_entries_on_feed_id ON updated_entries USING btree (feed_id);
 
 
 --
--- Name: index_updated_entries_on_user_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_updated_entries_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_updated_entries_on_user_id ON updated_entries USING btree (user_id);
 
 
 --
--- Name: index_updated_entries_on_user_id_and_entry_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_updated_entries_on_user_id_and_entry_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_updated_entries_on_user_id_and_entry_id ON updated_entries USING btree (user_id, entry_id);
 
 
 --
--- Name: index_users_on_auth_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_auth_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_auth_token ON users USING btree (auth_token);
 
 
 --
--- Name: index_users_on_customer_id; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_customer_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_customer_id ON users USING btree (customer_id);
 
 
 --
--- Name: index_users_on_expires_at; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_expires_at; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_expires_at ON users USING btree (expires_at);
 
 
 --
--- Name: index_users_on_inbound_email_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_inbound_email_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_inbound_email_token ON users USING btree (inbound_email_token);
 
 
 --
--- Name: index_users_on_lower_email; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_lower_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_lower_email ON users USING btree (lower((email)::text));
 
 
 --
--- Name: index_users_on_newsletter_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_newsletter_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_newsletter_token ON users USING btree (newsletter_token);
 
 
 --
--- Name: index_users_on_password_reset_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_password_reset_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_password_reset_token ON users USING btree (password_reset_token);
 
 
 --
--- Name: index_users_on_starred_token; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: index_users_on_starred_token; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_users_on_starred_token ON users USING btree (starred_token);
 
 
 --
--- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+-- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (version);
@@ -1794,7 +1985,7 @@ CREATE UNIQUE INDEX unique_schema_migrations ON schema_migrations USING btree (v
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO "$user",public;
+SET search_path TO "$user", public;
 
 INSERT INTO schema_migrations (version) VALUES ('20121010042043');
 
@@ -2043,4 +2234,6 @@ INSERT INTO schema_migrations (version) VALUES ('20151110044837');
 INSERT INTO schema_migrations (version) VALUES ('20151207224028');
 
 INSERT INTO schema_migrations (version) VALUES ('20160126003712');
+
+INSERT INTO schema_migrations (version) VALUES ('20160131175812');
 

--- a/lib/basic_authentication.rb
+++ b/lib/basic_authentication.rb
@@ -4,7 +4,9 @@ class BasicAuthentication
   end
 
   def call(env)
-    if env['HTTP_AUTHORIZATION'].respond_to?(:include?) && !env['HTTP_AUTHORIZATION'].include?('Basic') && !env['HTTP_AUTHORIZATION'].include?('ApplePushNotifications')
+    excluded_headers = ['Basic', 'ApplePushNotifications', 'Bearer']
+
+    if env['HTTP_AUTHORIZATION'].respond_to?(:include?) && excluded_headers.none? { |header| env['HTTP_AUTHORIZATION'].include?(header) }
       env['HTTP_AUTHORIZATION'] = "Basic #{env['HTTP_AUTHORIZATION']}"
     end
     @app.call(env)


### PR DESCRIPTION
This adds the popular [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) gem for OAuth 2 authentication for API endpoints. There's a lot of boilerplate code provided by the doorkeeper generators. There's also a lot of small diffs in the structure.sql file that occurred when I ran the migration.

Here's what the authorization page looks like:
![screen shot 2016-01-31 at 7 48 21 pm](https://cloud.githubusercontent.com/assets/344174/12708379/b16e003c-c853-11e5-9677-d999d95122fb.png)

And the Applications page in Settings:
![screen shot 2016-01-31 at 7 48 36 pm](https://cloud.githubusercontent.com/assets/344174/12708386/b9852c00-c853-11e5-99a7-97c9b5aa9284.png)

I'm totally happy to make changes to these views too.