### PR TITLE
Support delta feeds

### DIFF
--- a/app/models/feed_request.rb
+++ b/app/models/feed_request.rb
@@ -114,6 +114,9 @@ class FeedRequest
       if @options.has_key?(:if_none_match)
         curl.headers["If-None-Match"] = @options[:if_none_match]
       end
+      if @options.has_key?(:if_modified_since) || @options.has_key?(:if_none_match)
+        curl.headers["A-IM"] = "feed"
+      end
       curl.headers["User-Agent"] = @options[:user_agent] || "Feedbin"
       curl.headers["Accept-Encoding"] = "gzip"
       curl.connect_timeout = 10


### PR DESCRIPTION
Append A-IM request header when either If-Modified-Since or If-None-Match headers are set.

[Feed delta updates](https://www.slightfuture.com/webdev/feed-delta-updates) (like RFC3229+feed) only includes new entries added since the feed was fetched the last time. Saves bandwidth for feed servers and users alike. Means less processing as only new and modified entries are included in the feed. 
