### PR TITLE
Allow small tag

### DIFF
--- a/config/initializers/whitelist.rb
+++ b/config/initializers/whitelist.rb
@@ -6,6 +6,7 @@ class Whitelist
         h1 h2 h3 h4 h5 h6 h7 h8 br b i strong em a pre code img tt div ins del sup sub
         p ol ul table thead tbody tfoot blockquote dl dt dd kbd q samp var hr ruby rt
         rp li tr td th s strike summary details figure figcaption audio video source
+        small
       ]
 
       hash[:attributes] = {


### PR DESCRIPTION
I updated one of my feeds to use this and noticed it's filtered out.

Not sure if belongs here or in the html-pipeline itself.