### PR TITLE
Support minio as AWS S3 replacement.

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,11 +1,22 @@
 if ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
   CarrierWave.configure do |config|
     config.fog_provider = 'fog/aws'
-    config.fog_credentials = {
-      provider: "AWS",
-      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]
-    }
+    if ENV["MINIO_HOST"] && ENV["MINIO_ENDPOINT"]
+      config.fog_credentials = {
+        provider: "AWS",
+        aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+        host: ENV["MINIO_HOST"],
+        endpoint: ENV["MINIO_ENDPOINT"],
+        path_style: true
+      }
+    else
+      config.fog_credentials = {
+        provider: "AWS",
+        aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"]
+      }
+    end
     config.fog_directory = ENV["AWS_S3_BUCKET"]
     config.max_file_size = 75.megabytes
   end


### PR DESCRIPTION
Minio should work the same as S3 except that it needs different host-
and endpoint settings.

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>