### PR TITLE
Update migrations to new Rails 5.0 syntax

### DIFF
--- a/db/migrate/20121010042043_devise_create_users.rb
+++ b/db/migrate/20121010042043_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20121011035904_create_feeds.rb
+++ b/db/migrate/20121011035904_create_feeds.rb
@@ -1,4 +1,4 @@
-class CreateFeeds < ActiveRecord::Migration
+class CreateFeeds < ActiveRecord::Migration[4.2]
 
   def change
     create_table :feeds do |t|

--- a/db/migrate/20121011035933_create_subscriptions.rb
+++ b/db/migrate/20121011035933_create_subscriptions.rb
@@ -1,4 +1,4 @@
-class CreateSubscriptions < ActiveRecord::Migration
+class CreateSubscriptions < ActiveRecord::Migration[4.2]
 
   def change
     create_table :subscriptions do |t|

--- a/db/migrate/20121012074155_create_entries.rb
+++ b/db/migrate/20121012074155_create_entries.rb
@@ -1,4 +1,4 @@
-class CreateEntries < ActiveRecord::Migration
+class CreateEntries < ActiveRecord::Migration[4.2]
 
   def change
     create_table :entries do |t|

--- a/db/migrate/20121012075009_create_entry_states.rb
+++ b/db/migrate/20121012075009_create_entry_states.rb
@@ -1,4 +1,4 @@
-class CreateEntryStates < ActiveRecord::Migration
+class CreateEntryStates < ActiveRecord::Migration[4.2]
 
   def change
     create_table :entry_states do |t|

--- a/db/migrate/20121013082327_add_feed_id_to_entry_states.rb
+++ b/db/migrate/20121013082327_add_feed_id_to_entry_states.rb
@@ -1,4 +1,4 @@
-class AddFeedIdToEntryStates < ActiveRecord::Migration
+class AddFeedIdToEntryStates < ActiveRecord::Migration[4.2]
   def up
     add_column :entry_states, :feed_id, :integer
     add_index :entry_states, :feed_id

--- a/db/migrate/20121019045613_add_last_modified_to_feed.rb
+++ b/db/migrate/20121019045613_add_last_modified_to_feed.rb
@@ -1,4 +1,4 @@
-class AddLastModifiedToFeed < ActiveRecord::Migration
+class AddLastModifiedToFeed < ActiveRecord::Migration[4.2]
   def change
     add_column :feeds, :last_modified, :datetime
   end

--- a/db/migrate/20121019150248_remove_entry_id_from_entries.rb
+++ b/db/migrate/20121019150248_remove_entry_id_from_entries.rb
@@ -1,4 +1,4 @@
-class RemoveEntryIdFromEntries < ActiveRecord::Migration
+class RemoveEntryIdFromEntries < ActiveRecord::Migration[4.2]
   def up
     remove_index :entries, :entry_id
     remove_column :entries, :entry_id

--- a/db/migrate/20121019231945_add_selected_feed_to_users.rb
+++ b/db/migrate/20121019231945_add_selected_feed_to_users.rb
@@ -1,4 +1,4 @@
-class AddSelectedFeedToUsers < ActiveRecord::Migration
+class AddSelectedFeedToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :selected_feed, :integer
   end

--- a/db/migrate/20121023224542_add_url_index_to_entries.rb
+++ b/db/migrate/20121023224542_add_url_index_to_entries.rb
@@ -1,4 +1,4 @@
-class AddUrlIndexToEntries < ActiveRecord::Migration
+class AddUrlIndexToEntries < ActiveRecord::Migration[4.2]
   def up
     add_index :entries, :url
   end

--- a/db/migrate/20121029015723_add_selected_entry_to_users.rb
+++ b/db/migrate/20121029015723_add_selected_entry_to_users.rb
@@ -1,4 +1,4 @@
-class AddSelectedEntryToUsers < ActiveRecord::Migration
+class AddSelectedEntryToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :selected_entry, :integer
   end

--- a/db/migrate/20121106123418_create_settings.rb
+++ b/db/migrate/20121106123418_create_settings.rb
@@ -1,4 +1,4 @@
-class CreateSettings < ActiveRecord::Migration
+class CreateSettings < ActiveRecord::Migration[4.2]
   def self.up
     create_table :settings do |t|
       t.string :var, :null => false

--- a/db/migrate/20121109200937_remove_selected_feed_and_selected_entry_from_users.rb
+++ b/db/migrate/20121109200937_remove_selected_feed_and_selected_entry_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveSelectedFeedAndSelectedEntryFromUsers < ActiveRecord::Migration
+class RemoveSelectedFeedAndSelectedEntryFromUsers < ActiveRecord::Migration[4.2]
   def up
     remove_column :users, :selected_feed
     remove_column :users, :selected_entry

--- a/db/migrate/20121115044716_remove_feed_id_and_entry_id_index_from_entries.rb
+++ b/db/migrate/20121115044716_remove_feed_id_and_entry_id_index_from_entries.rb
@@ -1,4 +1,4 @@
-class RemoveFeedIdAndEntryIdIndexFromEntries < ActiveRecord::Migration
+class RemoveFeedIdAndEntryIdIndexFromEntries < ActiveRecord::Migration[4.2]
   def up
     remove_index(:entries, name: :index_entries_on_feed_id_and_entry_id)
   end

--- a/db/migrate/20121117212752_add_indexes_to_entry_states.rb
+++ b/db/migrate/20121117212752_add_indexes_to_entry_states.rb
@@ -1,4 +1,4 @@
-class AddIndexesToEntryStates < ActiveRecord::Migration
+class AddIndexesToEntryStates < ActiveRecord::Migration[4.2]
   def up
     add_index :entry_states, :read
     add_index :entry_states, :starred

--- a/db/migrate/20121117225703_add_published_index_to_entries.rb
+++ b/db/migrate/20121117225703_add_published_index_to_entries.rb
@@ -1,4 +1,4 @@
-class AddPublishedIndexToEntries < ActiveRecord::Migration
+class AddPublishedIndexToEntries < ActiveRecord::Migration[4.2]
   def up
     add_index :entries, :published
   end

--- a/db/migrate/20121124070158_create_imports.rb
+++ b/db/migrate/20121124070158_create_imports.rb
@@ -1,4 +1,4 @@
-class CreateImports < ActiveRecord::Migration
+class CreateImports < ActiveRecord::Migration[4.2]
   def change
     create_table :imports do |t|
       t.integer :user_id

--- a/db/migrate/20121124070242_add_attachment_file_to_imports.rb
+++ b/db/migrate/20121124070242_add_attachment_file_to_imports.rb
@@ -1,4 +1,4 @@
-class AddAttachmentFileToImports < ActiveRecord::Migration
+class AddAttachmentFileToImports < ActiveRecord::Migration[4.2]
   def self.up
     change_table :imports do |t|
       t.has_attached_file :file

--- a/db/migrate/20121125043913_add_default_value_to_import_default.rb
+++ b/db/migrate/20121125043913_add_default_value_to_import_default.rb
@@ -1,4 +1,4 @@
-class AddDefaultValueToImportDefault < ActiveRecord::Migration
+class AddDefaultValueToImportDefault < ActiveRecord::Migration[4.2]
   def up
     change_column :imports, :complete, :boolean, default: false
   end

--- a/db/migrate/20121125051935_create_import_items.rb
+++ b/db/migrate/20121125051935_create_import_items.rb
@@ -1,4 +1,4 @@
-class CreateImportItems < ActiveRecord::Migration
+class CreateImportItems < ActiveRecord::Migration[4.2]
   def change
     create_table :import_items do |t|
       t.integer :import_id

--- a/db/migrate/20121202173023_acts_as_taggable_on_migration.rb
+++ b/db/migrate/20121202173023_acts_as_taggable_on_migration.rb
@@ -1,4 +1,4 @@
-class ActsAsTaggableOnMigration < ActiveRecord::Migration
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]
   def self.up
     create_table :tags do |t|
       t.string :name

--- a/db/migrate/20121220043916_remove_settings_gem.rb
+++ b/db/migrate/20121220043916_remove_settings_gem.rb
@@ -1,4 +1,4 @@
-class RemoveSettingsGem < ActiveRecord::Migration
+class RemoveSettingsGem < ActiveRecord::Migration[4.2]
   def up
     drop_table :settings
   end

--- a/db/migrate/20121220044158_add_settings_to_users.rb
+++ b/db/migrate/20121220044158_add_settings_to_users.rb
@@ -1,4 +1,4 @@
-class AddSettingsToUsers < ActiveRecord::Migration
+class AddSettingsToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :settings, :text
   end

--- a/db/migrate/20130101205608_add_entry_id_and_public_id_to_entries.rb
+++ b/db/migrate/20130101205608_add_entry_id_and_public_id_to_entries.rb
@@ -1,4 +1,4 @@
-class AddEntryIdAndPublicIdToEntries < ActiveRecord::Migration
+class AddEntryIdAndPublicIdToEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :entries, :entry_id, :string
     add_column :entries, :public_id, :string

--- a/db/migrate/20130107050848_remove_url_index_from_entries.rb
+++ b/db/migrate/20130107050848_remove_url_index_from_entries.rb
@@ -1,4 +1,4 @@
-class RemoveUrlIndexFromEntries < ActiveRecord::Migration
+class RemoveUrlIndexFromEntries < ActiveRecord::Migration[4.2]
   def up
     remove_index :entries, :url
   end

--- a/db/migrate/20130108022157_use_text_for_feed_and_entry_properties.rb
+++ b/db/migrate/20130108022157_use_text_for_feed_and_entry_properties.rb
@@ -1,4 +1,4 @@
-class UseTextForFeedAndEntryProperties < ActiveRecord::Migration
+class UseTextForFeedAndEntryProperties < ActiveRecord::Migration[4.2]
   def up
     change_table :entries do |t|
       t.change :title, :text

--- a/db/migrate/20130121161637_add_billing_info_to_users.rb
+++ b/db/migrate/20130121161637_add_billing_info_to_users.rb
@@ -1,4 +1,4 @@
-class AddBillingInfoToUsers < ActiveRecord::Migration
+class AddBillingInfoToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :customer_id, :string
     add_column :users, :last_4_digits, :string

--- a/db/migrate/20130121162410_create_plans.rb
+++ b/db/migrate/20130121162410_create_plans.rb
@@ -1,4 +1,4 @@
-class CreatePlans < ActiveRecord::Migration
+class CreatePlans < ActiveRecord::Migration[4.2]
   def change
     create_table :plans do |t|
       t.string :stripe_id

--- a/db/migrate/20130121162825_add_plan_id_to_users.rb
+++ b/db/migrate/20130121162825_add_plan_id_to_users.rb
@@ -1,4 +1,4 @@
-class AddPlanIdToUsers < ActiveRecord::Migration
+class AddPlanIdToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :plan_id, :integer
   end

--- a/db/migrate/20130124120921_add_admin_to_user.rb
+++ b/db/migrate/20130124120921_add_admin_to_user.rb
@@ -1,4 +1,4 @@
-class AddAdminToUser < ActiveRecord::Migration
+class AddAdminToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :admin, :boolean, default: false
   end

--- a/db/migrate/20130124141157_create_billing_events.rb
+++ b/db/migrate/20130124141157_create_billing_events.rb
@@ -1,4 +1,4 @@
-class CreateBillingEvents < ActiveRecord::Migration
+class CreateBillingEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :billing_events do |t|
       t.text :details

--- a/db/migrate/20130124144546_add_customer_id_index_to_users.rb
+++ b/db/migrate/20130124144546_add_customer_id_index_to_users.rb
@@ -1,4 +1,4 @@
-class AddCustomerIdIndexToUsers < ActiveRecord::Migration
+class AddCustomerIdIndexToUsers < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :customer_id, unique: true
   end

--- a/db/migrate/20130124151206_add_event_id_to_billing_events.rb
+++ b/db/migrate/20130124151206_add_event_id_to_billing_events.rb
@@ -1,4 +1,4 @@
-class AddEventIdToBillingEvents < ActiveRecord::Migration
+class AddEventIdToBillingEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :billing_events, :event_id, :string
     add_index :billing_events, :event_id, unique: true

--- a/db/migrate/20130126044222_add_suspended_to_users.rb
+++ b/db/migrate/20130126044222_add_suspended_to_users.rb
@@ -1,4 +1,4 @@
-class AddSuspendedToUsers < ActiveRecord::Migration
+class AddSuspendedToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :suspended, :boolean, default: false
   end

--- a/db/migrate/20130202145544_rename_feed_title_to_title.rb
+++ b/db/migrate/20130202145544_rename_feed_title_to_title.rb
@@ -1,4 +1,4 @@
-class RenameFeedTitleToTitle < ActiveRecord::Migration
+class RenameFeedTitleToTitle < ActiveRecord::Migration[4.2]
   def change
     rename_column :feeds, :feed_title, :title
   end

--- a/db/migrate/20130203182936_add_state_timestamps_to_entry_states.rb
+++ b/db/migrate/20130203182936_add_state_timestamps_to_entry_states.rb
@@ -1,4 +1,4 @@
-class AddStateTimestampsToEntryStates < ActiveRecord::Migration
+class AddStateTimestampsToEntryStates < ActiveRecord::Migration[4.2]
   def change
     add_column :entry_states, :starred_at, :datetime
     add_column :entry_states, :read_at, :datetime

--- a/db/migrate/20130203185241_add_index_to_timestamps.rb
+++ b/db/migrate/20130203185241_add_index_to_timestamps.rb
@@ -1,4 +1,4 @@
-class AddIndexToTimestamps < ActiveRecord::Migration
+class AddIndexToTimestamps < ActiveRecord::Migration[4.2]
   def change
     add_index :entry_states, :updated_at
     add_index :entries, :created_at

--- a/db/migrate/20130204000143_add_timestamp_user_index_to_entry_states.rb
+++ b/db/migrate/20130204000143_add_timestamp_user_index_to_entry_states.rb
@@ -1,4 +1,4 @@
-class AddTimestampUserIndexToEntryStates < ActiveRecord::Migration
+class AddTimestampUserIndexToEntryStates < ActiveRecord::Migration[4.2]
   def change
     add_index :entry_states, [:user_id, :read_updated_at, :starred_updated_at], name: 'index_entry_states_on_user_and_state_timestamps'
   end

--- a/db/migrate/20130218220024_remove_file_from_imports.rb
+++ b/db/migrate/20130218220024_remove_file_from_imports.rb
@@ -1,4 +1,4 @@
-class RemoveFileFromImports < ActiveRecord::Migration
+class RemoveFileFromImports < ActiveRecord::Migration[4.2]
   def self.up
     drop_attached_file :imports, :file
   end

--- a/db/migrate/20130218221354_add_opml_to_imports.rb
+++ b/db/migrate/20130218221354_add_opml_to_imports.rb
@@ -1,4 +1,4 @@
-class AddOpmlToImports < ActiveRecord::Migration
+class AddOpmlToImports < ActiveRecord::Migration[4.2]
   def change
     add_column :imports, :opml, :string
   end

--- a/db/migrate/20130226190942_remove_users.rb
+++ b/db/migrate/20130226190942_remove_users.rb
@@ -1,4 +1,4 @@
-class RemoveUsers < ActiveRecord::Migration
+class RemoveUsers < ActiveRecord::Migration[4.2]
   def up
     drop_table :users
   end

--- a/db/migrate/20130226191831_create_users.rb
+++ b/db/migrate/20130226191831_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :email

--- a/db/migrate/20130227065820_add_account_stuff_to_users.rb
+++ b/db/migrate/20130227065820_add_account_stuff_to_users.rb
@@ -1,4 +1,4 @@
-class AddAccountStuffToUsers < ActiveRecord::Migration
+class AddAccountStuffToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :auth_token, :string
     add_column :users, :password_reset_token, :string

--- a/db/migrate/20130228150343_drop_acts_as_taggable_on_migration.rb
+++ b/db/migrate/20130228150343_drop_acts_as_taggable_on_migration.rb
@@ -1,4 +1,4 @@
-class DropActsAsTaggableOnMigration < ActiveRecord::Migration
+class DropActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]
   def up
     drop_table :taggings
     drop_table :tags

--- a/db/migrate/20130228151024_create_taggings.rb
+++ b/db/migrate/20130228151024_create_taggings.rb
@@ -1,4 +1,4 @@
-class CreateTaggings < ActiveRecord::Migration
+class CreateTaggings < ActiveRecord::Migration[4.2]
   def change
     create_table :taggings do |t|
       t.belongs_to :tag

--- a/db/migrate/20130301095638_add_indexes.rb
+++ b/db/migrate/20130301095638_add_indexes.rb
@@ -1,4 +1,4 @@
-class AddIndexes < ActiveRecord::Migration
+class AddIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :auth_token, unique: true
     add_index :taggings, [:user_id, :tag_id]

--- a/db/migrate/20130302033514_add_user_id_feed_id_index_to_taggings.rb
+++ b/db/migrate/20130302033514_add_user_id_feed_id_index_to_taggings.rb
@@ -1,4 +1,4 @@
-class AddUserIdFeedIdIndexToTaggings < ActiveRecord::Migration
+class AddUserIdFeedIdIndexToTaggings < ActiveRecord::Migration[4.2]
   def change
     add_index :taggings, [:user_id, :feed_id]
   end

--- a/db/migrate/20130326034638_use_text_for_entry_id.rb
+++ b/db/migrate/20130326034638_use_text_for_entry_id.rb
@@ -1,4 +1,4 @@
-class UseTextForEntryId < ActiveRecord::Migration
+class UseTextForEntryId < ActiveRecord::Migration[4.2]
   def up
     change_table :entries do |t|
       t.change :entry_id, :text

--- a/db/migrate/20130327174832_add_old_public_id_to_entries.rb
+++ b/db/migrate/20130327174832_add_old_public_id_to_entries.rb
@@ -1,4 +1,4 @@
-class AddOldPublicIdToEntries < ActiveRecord::Migration
+class AddOldPublicIdToEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :entries, :old_public_id, :string
   end

--- a/db/migrate/20130403032020_add_hstore_extension.rb
+++ b/db/migrate/20130403032020_add_hstore_extension.rb
@@ -1,4 +1,4 @@
-class AddHstoreExtension < ActiveRecord::Migration
+class AddHstoreExtension < ActiveRecord::Migration[4.2]
   def up
     execute 'CREATE EXTENSION hstore'
   end

--- a/db/migrate/20130403032414_remove_settings_from_users.rb
+++ b/db/migrate/20130403032414_remove_settings_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveSettingsFromUsers < ActiveRecord::Migration
+class RemoveSettingsFromUsers < ActiveRecord::Migration[4.2]
   def up
     remove_column :users, :settings
   end

--- a/db/migrate/20130403032846_add_hstore_settings_to_users.rb
+++ b/db/migrate/20130403032846_add_hstore_settings_to_users.rb
@@ -1,4 +1,4 @@
-class AddHstoreSettingsToUsers < ActiveRecord::Migration
+class AddHstoreSettingsToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :settings, :hstore
   end

--- a/db/migrate/20130407192646_remove_unused_indexes.rb
+++ b/db/migrate/20130407192646_remove_unused_indexes.rb
@@ -1,4 +1,4 @@
-class RemoveUnusedIndexes < ActiveRecord::Migration
+class RemoveUnusedIndexes < ActiveRecord::Migration[4.2]
   def change
     remove_index :entry_states, :starred
     remove_index :entry_states, :read

--- a/db/migrate/20130408045541_add_starred_token_to_user.rb
+++ b/db/migrate/20130408045541_add_starred_token_to_user.rb
@@ -1,4 +1,4 @@
-class AddStarredTokenToUser < ActiveRecord::Migration
+class AddStarredTokenToUser < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :starred_token, :string
     add_index :users, :starred_token, unique: true

--- a/db/migrate/20130420122821_add_images_to_entries.rb
+++ b/db/migrate/20130420122821_add_images_to_entries.rb
@@ -1,4 +1,4 @@
-class AddImagesToEntries < ActiveRecord::Migration
+class AddImagesToEntries < ActiveRecord::Migration[4.2]
   def change
     change_table :entries do |t|
       t.string :images, array: true

--- a/db/migrate/20130420171308_drop_images_from_entries.rb
+++ b/db/migrate/20130420171308_drop_images_from_entries.rb
@@ -1,4 +1,4 @@
-class DropImagesFromEntries < ActiveRecord::Migration
+class DropImagesFromEntries < ActiveRecord::Migration[4.2]
   def change
     remove_column :entries, :images
   end

--- a/db/migrate/20130420171357_add_images_to_entries_again.rb
+++ b/db/migrate/20130420171357_add_images_to_entries_again.rb
@@ -1,4 +1,4 @@
-class AddImagesToEntriesAgain < ActiveRecord::Migration
+class AddImagesToEntriesAgain < ActiveRecord::Migration[4.2]
   def change
     change_table :entries do |t|
       t.text :images, array: true

--- a/db/migrate/20130424132435_create_sharing_services.rb
+++ b/db/migrate/20130424132435_create_sharing_services.rb
@@ -1,4 +1,4 @@
-class CreateSharingServices < ActiveRecord::Migration
+class CreateSharingServices < ActiveRecord::Migration[4.2]
   def change
     create_table :sharing_services do |t|
       t.references :user

--- a/db/migrate/20130429063608_add_inbound_email_token_to_users.rb
+++ b/db/migrate/20130429063608_add_inbound_email_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddInboundEmailTokenToUsers < ActiveRecord::Migration
+class AddInboundEmailTokenToUsers < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :inbound_email_token, :string
     add_index :users, :inbound_email_token, unique: true

--- a/db/migrate/20130429152153_add_missing_inbound_email_tokens.rb
+++ b/db/migrate/20130429152153_add_missing_inbound_email_tokens.rb
@@ -1,4 +1,4 @@
-class AddMissingInboundEmailTokens < ActiveRecord::Migration
+class AddMissingInboundEmailTokens < ActiveRecord::Migration[4.2]
   def change
     User.where(inbound_email_token: nil).find_each do |user|
       user.generate_token(:inbound_email_token)

--- a/db/migrate/20130429154717_change_etag_to_text.rb
+++ b/db/migrate/20130429154717_change_etag_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeEtagToText < ActiveRecord::Migration
+class ChangeEtagToText < ActiveRecord::Migration[4.2]
   def up
     change_table :feeds do |t|
       t.change :etag, :text

--- a/db/migrate/20130508034554_create_unread_entries.rb
+++ b/db/migrate/20130508034554_create_unread_entries.rb
@@ -1,4 +1,4 @@
-class CreateUnreadEntries < ActiveRecord::Migration
+class CreateUnreadEntries < ActiveRecord::Migration[4.2]
   def change
     create_table :unread_entries do |t|
       t.references :user, index: true

--- a/db/migrate/20130514072924_create_starred_entries.rb
+++ b/db/migrate/20130514072924_create_starred_entries.rb
@@ -1,4 +1,4 @@
-class CreateStarredEntries < ActiveRecord::Migration
+class CreateStarredEntries < ActiveRecord::Migration[4.2]
   def change
     create_table :starred_entries do |t|
       t.references :user, index: true

--- a/db/migrate/20130515203825_add_entry_created_at_to_unread_entries.rb
+++ b/db/migrate/20130515203825_add_entry_created_at_to_unread_entries.rb
@@ -1,4 +1,4 @@
-class AddEntryCreatedAtToUnreadEntries < ActiveRecord::Migration
+class AddEntryCreatedAtToUnreadEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :unread_entries, :entry_created_at, :datetime
     add_index :unread_entries, :entry_created_at

--- a/db/migrate/20130517164043_remove_entry_created_at_index_from_unread_entries.rb
+++ b/db/migrate/20130517164043_remove_entry_created_at_index_from_unread_entries.rb
@@ -1,4 +1,4 @@
-class RemoveEntryCreatedAtIndexFromUnreadEntries < ActiveRecord::Migration
+class RemoveEntryCreatedAtIndexFromUnreadEntries < ActiveRecord::Migration[4.2]
   def change
     remove_index :unread_entries, :entry_created_at
   end

--- a/db/migrate/20130520012402_add_title_to_subscriptions.rb
+++ b/db/migrate/20130520012402_add_title_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddTitleToSubscriptions < ActiveRecord::Migration
+class AddTitleToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :title, :text
   end

--- a/db/migrate/20130531231556_drop_created_at_index_on_entries.rb
+++ b/db/migrate/20130531231556_drop_created_at_index_on_entries.rb
@@ -1,4 +1,4 @@
-class DropCreatedAtIndexOnEntries < ActiveRecord::Migration
+class DropCreatedAtIndexOnEntries < ActiveRecord::Migration[4.2]
   def self.up
     remove_index :entries, :created_at
   end

--- a/db/migrate/20130616023624_rename_imports_opml_to_upload.rb
+++ b/db/migrate/20130616023624_rename_imports_opml_to_upload.rb
@@ -1,4 +1,4 @@
-class RenameImportsOpmlToUpload < ActiveRecord::Migration
+class RenameImportsOpmlToUpload < ActiveRecord::Migration[4.2]
   def change
     rename_column :imports, :opml, :upload
   end

--- a/db/migrate/20130616031049_add_item_type_to_import_items.rb
+++ b/db/migrate/20130616031049_add_item_type_to_import_items.rb
@@ -1,4 +1,4 @@
-class AddItemTypeToImportItems < ActiveRecord::Migration
+class AddItemTypeToImportItems < ActiveRecord::Migration[4.2]
   def change
     add_column :import_items, :item_type, :string
   end

--- a/db/migrate/20130619222820_add_view_inline_to_subscriptions.rb
+++ b/db/migrate/20130619222820_add_view_inline_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddViewInlineToSubscriptions < ActiveRecord::Migration
+class AddViewInlineToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :view_inline, :boolean, default: false
   end

--- a/db/migrate/20130701042440_add_price_tier_to_plans.rb
+++ b/db/migrate/20130701042440_add_price_tier_to_plans.rb
@@ -1,4 +1,4 @@
-class AddPriceTierToPlans < ActiveRecord::Migration
+class AddPriceTierToPlans < ActiveRecord::Migration[4.2]
   def change
     add_column :plans, :price_tier, :integer
   end

--- a/db/migrate/20130709054041_add_subscriptions_count_to_feeds.rb
+++ b/db/migrate/20130709054041_add_subscriptions_count_to_feeds.rb
@@ -1,4 +1,4 @@
-class AddSubscriptionsCountToFeeds < ActiveRecord::Migration
+class AddSubscriptionsCountToFeeds < ActiveRecord::Migration[4.2]
   def self.up
     add_column :feeds, :subscriptions_count, :integer, null: false, default: 0
     Feed.reset_column_information

--- a/db/migrate/20130713170339_drop_entry_states.rb
+++ b/db/migrate/20130713170339_drop_entry_states.rb
@@ -1,4 +1,4 @@
-class DropEntryStates < ActiveRecord::Migration
+class DropEntryStates < ActiveRecord::Migration[4.2]
   def up
     drop_table :entry_states
   end

--- a/db/migrate/20130720194025_add_starred_entries_count_to_entries.rb
+++ b/db/migrate/20130720194025_add_starred_entries_count_to_entries.rb
@@ -1,4 +1,4 @@
-class AddStarredEntriesCountToEntries < ActiveRecord::Migration
+class AddStarredEntriesCountToEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :entries, :starred_entries_count, :integer, null: false, default: 0
   end

--- a/db/migrate/20130730090745_remove_images_from_entries.rb
+++ b/db/migrate/20130730090745_remove_images_from_entries.rb
@@ -1,4 +1,4 @@
-class RemoveImagesFromEntries < ActiveRecord::Migration
+class RemoveImagesFromEntries < ActiveRecord::Migration[4.2]
   def change
     remove_column :entries, :images
   end

--- a/db/migrate/20130731234248_add_starred_entries_count_index_to_entries.rb
+++ b/db/migrate/20130731234248_add_starred_entries_count_index_to_entries.rb
@@ -1,4 +1,4 @@
-class AddStarredEntriesCountIndexToEntries < ActiveRecord::Migration
+class AddStarredEntriesCountIndexToEntries < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
 
   def change

--- a/db/migrate/20130801194304_remove_starred_entries_count_index_from_entries.rb
+++ b/db/migrate/20130801194304_remove_starred_entries_count_index_from_entries.rb
@@ -1,4 +1,4 @@
-class RemoveStarredEntriesCountIndexFromEntries < ActiveRecord::Migration
+class RemoveStarredEntriesCountIndexFromEntries < ActiveRecord::Migration[4.2]
   def change
     remove_index :entries, :starred_entries_count
   end

--- a/db/migrate/20130820123435_add_coupons.rb
+++ b/db/migrate/20130820123435_add_coupons.rb
@@ -1,4 +1,4 @@
-class AddCoupons < ActiveRecord::Migration
+class AddCoupons < ActiveRecord::Migration[4.2]
   def change
     create_table :coupons do |t|
       t.references :user, index: true

--- a/db/migrate/20130826053351_index_users_on_lowercase_email.rb
+++ b/db/migrate/20130826053351_index_users_on_lowercase_email.rb
@@ -1,4 +1,4 @@
-class IndexUsersOnLowercaseEmail < ActiveRecord::Migration
+class IndexUsersOnLowercaseEmail < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
 
   def up

--- a/db/migrate/20131011204115_create_saved_searches.rb
+++ b/db/migrate/20131011204115_create_saved_searches.rb
@@ -1,4 +1,4 @@
-class CreateSavedSearches < ActiveRecord::Migration
+class CreateSavedSearches < ActiveRecord::Migration[4.2]
   def change
     create_table :saved_searches do |t|
       t.references :user, index: true, null: false

--- a/db/migrate/20131017013531_add_active_to_subscriptions.rb
+++ b/db/migrate/20131017013531_add_active_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddActiveToSubscriptions < ActiveRecord::Migration
+class AddActiveToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :active, :boolean, default: true
   end

--- a/db/migrate/20131024055750_add_push_to_subscriptions.rb
+++ b/db/migrate/20131024055750_add_push_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddPushToSubscriptions < ActiveRecord::Migration
+class AddPushToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :push, :boolean, default: false
   end

--- a/db/migrate/20131025172652_add_data_to_entries.rb
+++ b/db/migrate/20131025172652_add_data_to_entries.rb
@@ -1,4 +1,4 @@
-class AddDataToEntries < ActiveRecord::Migration
+class AddDataToEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :entries, :data, :json
   end

--- a/db/migrate/20131101024758_add_protected_to_feeds.rb
+++ b/db/migrate/20131101024758_add_protected_to_feeds.rb
@@ -1,4 +1,4 @@
-class AddProtectedToFeeds < ActiveRecord::Migration
+class AddProtectedToFeeds < ActiveRecord::Migration[4.2]
   def change
     add_column :feeds, :protected, :boolean, default: false
   end

--- a/db/migrate/20131101063139_create_actions.rb
+++ b/db/migrate/20131101063139_create_actions.rb
@@ -1,4 +1,4 @@
-class CreateActions < ActiveRecord::Migration
+class CreateActions < ActiveRecord::Migration[4.2]
   def change
     create_table :actions do |t|
       t.belongs_to :user, index: true

--- a/db/migrate/20131105035905_update_actions_all_feeds_default.rb
+++ b/db/migrate/20131105035905_update_actions_all_feeds_default.rb
@@ -1,4 +1,4 @@
-class UpdateActionsAllFeedsDefault < ActiveRecord::Migration
+class UpdateActionsAllFeedsDefault < ActiveRecord::Migration[4.2]
   def change
     change_column :actions, :all_feeds, :boolean, default: false
   end

--- a/db/migrate/20131106060451_move_push_notifications_to_actions.rb
+++ b/db/migrate/20131106060451_move_push_notifications_to_actions.rb
@@ -1,4 +1,4 @@
-class MovePushNotificationsToActions < ActiveRecord::Migration
+class MovePushNotificationsToActions < ActiveRecord::Migration[4.2]
   def up
     User.find_each do |user|
       begin

--- a/db/migrate/20131201051809_add_updated_content_to_entries.rb
+++ b/db/migrate/20131201051809_add_updated_content_to_entries.rb
@@ -1,4 +1,4 @@
-class AddUpdatedContentToEntries < ActiveRecord::Migration
+class AddUpdatedContentToEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :entries, :updated_content, :text
   end

--- a/db/migrate/20131202012915_add_push_expiration_to_feeds.rb
+++ b/db/migrate/20131202012915_add_push_expiration_to_feeds.rb
@@ -1,4 +1,4 @@
-class AddPushExpirationToFeeds < ActiveRecord::Migration
+class AddPushExpirationToFeeds < ActiveRecord::Migration[4.2]
   def change
     add_column :feeds, :push_expiration, :datetime
   end

--- a/db/migrate/20131205004751_add_original_to_entries.rb
+++ b/db/migrate/20131205004751_add_original_to_entries.rb
@@ -1,4 +1,4 @@
-class AddOriginalToEntries < ActiveRecord::Migration
+class AddOriginalToEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :entries, :original, :json
   end

--- a/db/migrate/20131205095630_remove_updated_content_from_entries.rb
+++ b/db/migrate/20131205095630_remove_updated_content_from_entries.rb
@@ -1,4 +1,4 @@
-class RemoveUpdatedContentFromEntries < ActiveRecord::Migration
+class RemoveUpdatedContentFromEntries < ActiveRecord::Migration[4.2]
   def change
     remove_column :entries, :updated_content
   end

--- a/db/migrate/20131228183918_add_source_to_entries.rb
+++ b/db/migrate/20131228183918_add_source_to_entries.rb
@@ -1,4 +1,4 @@
-class AddSourceToEntries < ActiveRecord::Migration
+class AddSourceToEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :entries, :source, :text
   end

--- a/db/migrate/20131231084130_add_tag_visibility_to_users.rb
+++ b/db/migrate/20131231084130_add_tag_visibility_to_users.rb
@@ -1,4 +1,4 @@
-class AddTagVisibilityToUsers < ActiveRecord::Migration
+class AddTagVisibilityToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :tag_visibility, :json, default: {}
   end

--- a/db/migrate/20140116101303_index_unread_entries_on_user_id_and_created_at.rb
+++ b/db/migrate/20140116101303_index_unread_entries_on_user_id_and_created_at.rb
@@ -1,4 +1,4 @@
-class IndexUnreadEntriesOnUserIdAndCreatedAt < ActiveRecord::Migration
+class IndexUnreadEntriesOnUserIdAndCreatedAt < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   def change
     add_index :unread_entries, [:user_id, :created_at], algorithm: :concurrently

--- a/db/migrate/20140218235831_add_last_published_entry_to_feeds.rb
+++ b/db/migrate/20140218235831_add_last_published_entry_to_feeds.rb
@@ -1,4 +1,4 @@
-class AddLastPublishedEntryToFeeds < ActiveRecord::Migration
+class AddLastPublishedEntryToFeeds < ActiveRecord::Migration[4.2]
   def up
     add_column :feeds, :last_published_entry, :datetime
     add_index :feeds, :last_published_entry

--- a/db/migrate/20140223114030_create_feed_stats.rb
+++ b/db/migrate/20140223114030_create_feed_stats.rb
@@ -1,4 +1,4 @@
-class CreateFeedStats < ActiveRecord::Migration
+class CreateFeedStats < ActiveRecord::Migration[4.2]
   def change
     create_table :feed_stats do |t|
       t.belongs_to :feed, index: true

--- a/db/migrate/20140227001243_create_recently_read_entries.rb
+++ b/db/migrate/20140227001243_create_recently_read_entries.rb
@@ -1,4 +1,4 @@
-class CreateRecentlyReadEntries < ActiveRecord::Migration
+class CreateRecentlyReadEntries < ActiveRecord::Migration[4.2]
   def change
     create_table :recently_read_entries do |t|
       t.references :user, index: true

--- a/db/migrate/20140321203637_index_entries_on_created_at.rb
+++ b/db/migrate/20140321203637_index_entries_on_created_at.rb
@@ -1,4 +1,4 @@
-class IndexEntriesOnCreatedAt < ActiveRecord::Migration
+class IndexEntriesOnCreatedAt < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   def change
     add_index :entries, :created_at, order: {created_at: :desc}, algorithm: :concurrently

--- a/db/migrate/20140326173619_remove_created_at_index_from_entries.rb
+++ b/db/migrate/20140326173619_remove_created_at_index_from_entries.rb
@@ -1,4 +1,4 @@
-class RemoveCreatedAtIndexFromEntries < ActiveRecord::Migration
+class RemoveCreatedAtIndexFromEntries < ActiveRecord::Migration[4.2]
   def change
     remove_index :entries, :created_at
   end

--- a/db/migrate/20140416025157_create_supported_sharing_services.rb
+++ b/db/migrate/20140416025157_create_supported_sharing_services.rb
@@ -1,4 +1,4 @@
-class CreateSupportedSharingServices < ActiveRecord::Migration
+class CreateSupportedSharingServices < ActiveRecord::Migration[4.2]
   def change
     create_table :supported_sharing_services do |t|
       t.belongs_to :user, index: true, null: false

--- a/db/migrate/20140505062817_create_deleted_users.rb
+++ b/db/migrate/20140505062817_create_deleted_users.rb
@@ -1,4 +1,4 @@
-class CreateDeletedUsers < ActiveRecord::Migration
+class CreateDeletedUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :deleted_users do |t|
       t.text :email

--- a/db/migrate/20140823091357_create_favicons.rb
+++ b/db/migrate/20140823091357_create_favicons.rb
@@ -1,4 +1,4 @@
-class CreateFavicons < ActiveRecord::Migration
+class CreateFavicons < ActiveRecord::Migration[4.2]
   def change
     create_table :favicons do |t|
       t.text :host

--- a/db/migrate/20140823094323_add_host_to_feeds.rb
+++ b/db/migrate/20140823094323_add_host_to_feeds.rb
@@ -1,4 +1,4 @@
-class AddHostToFeeds < ActiveRecord::Migration
+class AddHostToFeeds < ActiveRecord::Migration[4.2]
   def change
     add_column :feeds, :host, :text
     add_index :feeds, :host

--- a/db/migrate/20141022031229_add_title_to_actions.rb
+++ b/db/migrate/20141022031229_add_title_to_actions.rb
@@ -1,4 +1,4 @@
-class AddTitleToActions < ActiveRecord::Migration
+class AddTitleToActions < ActiveRecord::Migration[4.2]
   def change
     add_column :actions, :title, :text
   end

--- a/db/migrate/20141110225053_remove_id_from_unread_entries.rb
+++ b/db/migrate/20141110225053_remove_id_from_unread_entries.rb
@@ -1,4 +1,4 @@
-class RemoveIdFromUnreadEntries < ActiveRecord::Migration
+class RemoveIdFromUnreadEntries < ActiveRecord::Migration[4.2]
   def change
     remove_column :unread_entries, :id
   end

--- a/db/migrate/20141117192421_create_updated_entries.rb
+++ b/db/migrate/20141117192421_create_updated_entries.rb
@@ -1,4 +1,4 @@
-class CreateUpdatedEntries < ActiveRecord::Migration
+class CreateUpdatedEntries < ActiveRecord::Migration[4.2]
   def change
     create_table :updated_entries, id: :bigserial do |t|
       t.belongs_to :user, index: true

--- a/db/migrate/20141202203934_add_show_updates_and_muted_to_subscriptions.rb
+++ b/db/migrate/20141202203934_add_show_updates_and_muted_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddShowUpdatesAndMutedToSubscriptions < ActiveRecord::Migration
+class AddShowUpdatesAndMutedToSubscriptions < ActiveRecord::Migration[4.2]
 
   def up
     add_column :subscriptions, :show_updates, :boolean

--- a/db/migrate/20141208231955_index_subscriptions_on_feed_id_active_muted.rb
+++ b/db/migrate/20141208231955_index_subscriptions_on_feed_id_active_muted.rb
@@ -1,4 +1,4 @@
-class IndexSubscriptionsOnFeedIdActiveMuted < ActiveRecord::Migration
+class IndexSubscriptionsOnFeedIdActiveMuted < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   def change
     add_index :subscriptions, [:feed_id, :active, :muted], algorithm: :concurrently

--- a/db/migrate/20141215195928_index_recently_read_entries_on_entry_id.rb
+++ b/db/migrate/20141215195928_index_recently_read_entries_on_entry_id.rb
@@ -1,4 +1,4 @@
-class IndexRecentlyReadEntriesOnEntryId < ActiveRecord::Migration
+class IndexRecentlyReadEntriesOnEntryId < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   def change
     add_index :recently_read_entries, :entry_id, algorithm: :concurrently

--- a/db/migrate/20150424224723_create_devices.rb
+++ b/db/migrate/20150424224723_create_devices.rb
@@ -1,4 +1,4 @@
-class CreateDevices < ActiveRecord::Migration
+class CreateDevices < ActiveRecord::Migration[4.2]
   def change
     create_table :devices do |t|
       t.belongs_to :user, index: true

--- a/db/migrate/20150425060924_add_tag_ids_and_action_type_to_actions.rb
+++ b/db/migrate/20150425060924_add_tag_ids_and_action_type_to_actions.rb
@@ -1,4 +1,4 @@
-class AddTagIdsAndActionTypeToActions < ActiveRecord::Migration
+class AddTagIdsAndActionTypeToActions < ActiveRecord::Migration[4.2]
   def change
     add_column :actions, :tag_ids, :integer, array: true, default: []
     add_column :actions, :action_type, :integer, default: 0

--- a/db/migrate/20150520213553_index_devices_on_lowercase_token.rb
+++ b/db/migrate/20150520213553_index_devices_on_lowercase_token.rb
@@ -1,4 +1,4 @@
-class IndexDevicesOnLowercaseToken < ActiveRecord::Migration
+class IndexDevicesOnLowercaseToken < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
 
   def up

--- a/db/migrate/20150602223929_add_application_and_operating_system_to_devices.rb
+++ b/db/migrate/20150602223929_add_application_and_operating_system_to_devices.rb
@@ -1,4 +1,4 @@
-class AddApplicationAndOperatingSystemToDevices < ActiveRecord::Migration
+class AddApplicationAndOperatingSystemToDevices < ActiveRecord::Migration[4.2]
   def change
     add_column :devices, :application, :text
     add_column :devices, :operating_system, :text

--- a/db/migrate/20150626223113_add_expires_at_to_users.rb
+++ b/db/migrate/20150626223113_add_expires_at_to_users.rb
@@ -1,4 +1,4 @@
-class AddExpiresAtToUsers < ActiveRecord::Migration
+class AddExpiresAtToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :expires_at, :datetime
     add_index :users, :expires_at

--- a/db/migrate/20150707202540_create_in_app_purchases.rb
+++ b/db/migrate/20150707202540_create_in_app_purchases.rb
@@ -1,4 +1,4 @@
-class CreateInAppPurchases < ActiveRecord::Migration
+class CreateInAppPurchases < ActiveRecord::Migration[4.2]
   def change
     create_table :in_app_purchases do |t|
       t.belongs_to :user, index: true

--- a/db/migrate/20150713230754_create_suggested_categories.rb
+++ b/db/migrate/20150713230754_create_suggested_categories.rb
@@ -1,4 +1,4 @@
-class CreateSuggestedCategories < ActiveRecord::Migration
+class CreateSuggestedCategories < ActiveRecord::Migration[4.2]
   def change
     create_table :suggested_categories do |t|
       t.text :name

--- a/db/migrate/20150714000523_create_suggested_feeds.rb
+++ b/db/migrate/20150714000523_create_suggested_feeds.rb
@@ -1,4 +1,4 @@
-class CreateSuggestedFeeds < ActiveRecord::Migration
+class CreateSuggestedFeeds < ActiveRecord::Migration[4.2]
   def change
     create_table :suggested_feeds do |t|
       t.belongs_to :suggested_category, index: true

--- a/db/migrate/20150817230441_add_response_to_in_app_purchases.rb
+++ b/db/migrate/20150817230441_add_response_to_in_app_purchases.rb
@@ -1,4 +1,4 @@
-class AddResponseToInAppPurchases < ActiveRecord::Migration
+class AddResponseToInAppPurchases < ActiveRecord::Migration[4.2]
   def change
     add_column :in_app_purchases, :response, :json
   end

--- a/db/migrate/20150827230751_add_source_to_starred_entries.rb
+++ b/db/migrate/20150827230751_add_source_to_starred_entries.rb
@@ -1,4 +1,4 @@
-class AddSourceToStarredEntries < ActiveRecord::Migration
+class AddSourceToStarredEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :starred_entries, :source, :text
   end

--- a/db/migrate/20151011143618_add_image_url_to_entries.rb
+++ b/db/migrate/20151011143618_add_image_url_to_entries.rb
@@ -1,4 +1,4 @@
-class AddImageUrlToEntries < ActiveRecord::Migration
+class AddImageUrlToEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :entries, :image_url, :text
     add_column :entries, :processed_image_url, :text

--- a/db/migrate/20151019200512_add_image_to_entries.rb
+++ b/db/migrate/20151019200512_add_image_to_entries.rb
@@ -1,4 +1,4 @@
-class AddImageToEntries < ActiveRecord::Migration
+class AddImageToEntries < ActiveRecord::Migration[4.2]
   def change
     add_column :entries, :image, :json
   end

--- a/db/migrate/20151110044837_add_newsletter_token_to_users.rb
+++ b/db/migrate/20151110044837_add_newsletter_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddNewsletterTokenToUsers < ActiveRecord::Migration
+class AddNewsletterTokenToUsers < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :newsletter_token, :string
     add_index :users, :newsletter_token, unique: true

--- a/db/migrate/20151207224028_add_self_url_to_feed.rb
+++ b/db/migrate/20151207224028_add_self_url_to_feed.rb
@@ -1,4 +1,4 @@
-class AddSelfUrlToFeed < ActiveRecord::Migration
+class AddSelfUrlToFeed < ActiveRecord::Migration[4.2]
   def change
     add_column :feeds, :self_url, :text
   end

--- a/db/migrate/20160126003712_add_feed_type_to_feed.rb
+++ b/db/migrate/20160126003712_add_feed_type_to_feed.rb
@@ -1,4 +1,4 @@
-class AddFeedTypeToFeed < ActiveRecord::Migration
+class AddFeedTypeToFeed < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   def up
     add_column :feeds, :feed_type, :integer

--- a/db/migrate/20160504184656_add_data_to_favicons.rb
+++ b/db/migrate/20160504184656_add_data_to_favicons.rb
@@ -1,4 +1,4 @@
-class AddDataToFavicons < ActiveRecord::Migration
+class AddDataToFavicons < ActiveRecord::Migration[4.2]
   def change
     add_column :favicons, :data, :json
   end

--- a/db/migrate/20160709063934_add_active_to_feeds.rb
+++ b/db/migrate/20160709063934_add_active_to_feeds.rb
@@ -1,4 +1,4 @@
-class AddActiveToFeeds < ActiveRecord::Migration
+class AddActiveToFeeds < ActiveRecord::Migration[4.2]
   disable_ddl_transaction!
   def up
     add_column :feeds, :active, :boolean

--- a/db/migrate/20160817165958_add_info_to_billing_events.rb
+++ b/db/migrate/20160817165958_add_info_to_billing_events.rb
@@ -1,4 +1,4 @@
-class AddInfoToBillingEvents < ActiveRecord::Migration
+class AddInfoToBillingEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :billing_events, :info, :json
   end

--- a/db/migrate/20160822194302_add_options_to_feeds.rb
+++ b/db/migrate/20160822194302_add_options_to_feeds.rb
@@ -1,4 +1,4 @@
-class AddOptionsToFeeds < ActiveRecord::Migration
+class AddOptionsToFeeds < ActiveRecord::Migration[4.2]
   def change
     add_column :feeds, :options, :json
   end


### PR DESCRIPTION
This is first fix for making application bootstrap work again: `rails db:create db:migrate`.

In Rails 5.0 migrations was changed.

`Version the API presented to migration classes, so we can change parameter defaults without breaking existing migrations, or forcing them to be rewritten through a deprecation cycle.` See more at: rails/rails#21538

In 5.0 they add deprecation warning about this: "Directly inheriting from ActiveRecord::Migration is deprecated. Please specify the Rails release the migration was written for"

In 5.1 they change deprecation warning to error: "Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:"

```
Created database 'feedbin_development'
Created database 'feedbin_test'
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class DeviseCreateUsers < ActiveRecord::Migration[4.2]
/Users/biow0lf/opensource/feedbin/db/migrate/20121010042043_devise_create_users.rb:1:in `<main>'
bin/rails:4:in `<main>'

Caused by:
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class DeviseCreateUsers < ActiveRecord::Migration[4.2]
/Users/biow0lf/opensource/feedbin/db/migrate/20121010042043_devise_create_users.rb:1:in `<main>'
bin/rails:4:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

This pull request fix this by changing inheritance from `ActiveRecord::Migration` to `ActiveRecord::Migration[4.2]`.
