### PR TITLE
Increased colour contrast for feed "drawers"

### DIFF
--- a/app/assets/stylesheets/_site.scss
+++ b/app/assets/stylesheets/_site.scss
@@ -1694,6 +1694,9 @@ $hamburger-dot: 4px;
         overflow: hidden;
         opacity: 1;
         transition: opacity .3s linear;
+        @include background-color($color-contrast-100);
+        @include border-top($color-contrast-200);
+        @include border-bottom($color-contrast-200);
         &.hidden {
             opacity: 0;
         }


### PR DESCRIPTION
I love the [new look](https://feedbin.com/blog/2019/07/08/three-columns/). But I found myself really struggling to find the feeds I was after because I couldn’t differentiate between tag folders and feeds:

![now](https://user-images.githubusercontent.com/739624/60882662-402fec80-a240-11e9-812b-b8d21f6cab97.png)

I went to Twitter to see whether anyone else was talking about the change, and noticed [I wasn’t alone in feeling like the sidebar now lacks contrast](https://twitter.com/skernjak/status/1148176734308712448).

So I figured, to get some discussion going, I’d submit a PR of how it _could_ look with some very subtle shading.

![demo](https://user-images.githubusercontent.com/739624/60882794-871de200-a240-11e9-9315-fbdefcf3f03d.png)

I’m not presumptive enough to think that you’d actually merge this PR as-is. But hopefully it might spark some thinking about _whether_ you want to reintroduce some contrast for folders and feeds, and if so, _how_ you go about doing it.

There are obviously a number of ways to introduce visual contrast. For instance, if you still wanted to retain the new "flat" appearance—or you’re worried that a shading-based approach doesn’t pass accessibility requirements—then maybe _indenting_ the folder contents might we a way to go?

![indented](https://user-images.githubusercontent.com/739624/60883291-b1bc6a80-a241-11e9-804a-6d3f05690e7e.png)

Thanks for you time!