### PR TITLE
User registration: don't create Stripe customer if API key missing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
   before_save :activate_subscriptions
   before_save { reset_auth_token }
 
-  before_create { create_customer }
+  before_create :create_customer, unless: -> { !ENV["STRIPE_API_KEY"] }
   before_create { generate_token(:starred_token) }
   before_create { generate_token(:inbound_email_token, 4) }
   before_create { generate_newsletter_token }


### PR DESCRIPTION
Multiple conditions are present in the project to make Stripe optionial, so I suppose you simply forgot this one.

Fix #240 #229 #338