### PR TITLE
S3: Add support for region, storage class and non-AWS providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ export AWS_ACCESS_KEY_ID=
 export AWS_S3_BUCKET=
 export AWS_SECRET_ACCESS_KEY=
 export AWS_S3_REGION=
+export AWS_S3_STORAGE_CLASS=
 
 # Required to enable certain features
 export ANALYTICS_DOMAIN=

--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,12 @@ export RAILS_ENV=production
 export AWS_ACCESS_KEY_ID=
 export AWS_S3_BUCKET=
 export AWS_SECRET_ACCESS_KEY=
-# Optional settings, mendatory if using another object storage provider
 export AWS_S3_REGION=
+# Optional settings, might be useful for other object storage providers
 export AWS_S3_HOST=
 export AWS_S3_STORAGE_CLASS=
+export AWS_S3_ENDPOINT=
+export AWS_S3_PATH_STYLE=
 
 # Required to enable certain features
 export ANALYTICS_DOMAIN=

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ export RAILS_ENV=production
 export AWS_ACCESS_KEY_ID=
 export AWS_S3_BUCKET=
 export AWS_SECRET_ACCESS_KEY=
+export AWS_S3_REGION=
 
 # Required to enable certain features
 export ANALYTICS_DOMAIN=

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,9 @@ export RAILS_ENV=production
 export AWS_ACCESS_KEY_ID=
 export AWS_S3_BUCKET=
 export AWS_SECRET_ACCESS_KEY=
+# Optional settings, mendatory if using another object storage provider
 export AWS_S3_REGION=
+export AWS_S3_HOST=
 export AWS_S3_STORAGE_CLASS=
 
 # Required to enable certain features

--- a/app/jobs/favicon_copy.rb
+++ b/app/jobs/favicon_copy.rb
@@ -20,7 +20,7 @@ class FaviconCopy
   STORAGE_OPTIONS = {
     "Cache-Control" => "max-age=315360000, public",
     "Expires" => "Sun, 29 Jun 2036 17:48:34 GMT",
-    "x-amz-storage-class" => "REDUCED_REDUNDANCY",
+    "x-amz-storage-class" => ENV["AWS_S3_STORAGE_CLASS"] || "REDUCED_REDUNDANCY",
   }
 
   def move

--- a/app/jobs/image_copy.rb
+++ b/app/jobs/image_copy.rb
@@ -28,7 +28,7 @@ class ImageCopy
   STORAGE_OPTIONS = {
     "Cache-Control" => "max-age=315360000, public",
     "Expires" => "Sun, 29 Jun 2036 17:48:34 GMT",
-    "x-amz-storage-class" => "REDUCED_REDUNDANCY",
+    "x-amz-storage-class" => ENV["AWS_S3_STORAGE_CLASS"] || "REDUCED_REDUNDANCY",
   }
 
   def s3_copy(url, append = "")

--- a/app/jobs/image_saver.rb
+++ b/app/jobs/image_saver.rb
@@ -20,7 +20,7 @@ class ImageSaver
   STORAGE_OPTIONS = {
     "Cache-Control" => "max-age=315360000, public",
     "Expires" => "Sun, 29 Jun 2036 17:48:34 GMT",
-    "x-amz-storage-class" => "REDUCED_REDUNDANCY",
+    "x-amz-storage-class" => ENV["AWS_S3_STORAGE_CLASS"] || "REDUCED_REDUNDANCY",
   }
 
   def content

--- a/app/jobs/newsletter_saver.rb
+++ b/app/jobs/newsletter_saver.rb
@@ -22,7 +22,7 @@ class NewsletterSaver
       "Cache-Control" => "max-age=315360000, public",
       "Expires" => "Sun, 29 Jun 2036 17:48:34 GMT",
       "x-amz-acl" => "public-read",
-      "x-amz-storage-class" => "REDUCED_REDUNDANCY",
+      "x-amz-storage-class" => ENV["AWS_S3_STORAGE_CLASS"] || "REDUCED_REDUNDANCY",
     }
   end
 end

--- a/app/models/favicon_processor.rb
+++ b/app/models/favicon_processor.rb
@@ -82,7 +82,7 @@ class FaviconProcessor
       "Cache-Control" => "max-age=315360000, public",
       "Expires" => "Sun, 29 Jun 2036 17:48:34 GMT",
       "x-amz-acl" => "public-read",
-      "x-amz-storage-class" => "REDUCED_REDUNDANCY",
+      "x-amz-storage-class" => ENV["AWS_S3_STORAGE_CLASS"] || "REDUCED_REDUNDANCY",
       "x-amz-meta-favicon-host" => host,
     }
   end

--- a/app/uploaders/entry_image_uploader.rb
+++ b/app/uploaders/entry_image_uploader.rb
@@ -9,7 +9,7 @@ class EntryImageUploader < CarrierWave::Uploader::Base
     {
       "Cache-Control" => "max-age=315360000, public",
       "Expires" => 20.years.from_now.httpdate,
-      "x-amz-storage-class" => "REDUCED_REDUNDANCY",
+      "x-amz-storage-class" => ENV["AWS_S3_STORAGE_CLASS"] || "REDUCED_REDUNDANCY",
     }
   end
 end

--- a/config/initializers/s3.rb
+++ b/config/initializers/s3.rb
@@ -6,6 +6,8 @@ if ENV["AWS_ACCESS_KEY_ID"]
       aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
       region: ENV["AWS_S3_REGION"] || "us-east-1",
       host: ENV["AWS_HOST"] || "s3.amazonaws.com",
+      endpoint: ENV["AWS_S3_ENDPOINT"] || nil,
+      path_style: ENV["AWS_S3_PATH_STYLE"] || false,
       persistent: true,
     )
   }

--- a/config/initializers/s3.rb
+++ b/config/initializers/s3.rb
@@ -4,6 +4,7 @@ if ENV["AWS_ACCESS_KEY_ID"]
       provider: "AWS",
       aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
       aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      region: ENV["AWS_S3_REGION"] || "us-east-1",
       persistent: true,
     )
   }

--- a/config/initializers/s3.rb
+++ b/config/initializers/s3.rb
@@ -5,6 +5,7 @@ if ENV["AWS_ACCESS_KEY_ID"]
       aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
       aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
       region: ENV["AWS_S3_REGION"] || "us-east-1",
+      host: ENV["AWS_HOST"] || "s3.amazonaws.com",
       persistent: true,
     )
   }


### PR DESCRIPTION
The first two commits can be useful even when sticking to AWS. However they are mandatory when using another provider.

These changes are compatible with both AWS and non-AWS providers.

Here is my config with Scaleway for instance:

```
export AWS_ACCESS_KEY_ID=xxxxx
export AWS_SECRET_ACCESS_KEY=xxxxxx
export AWS_S3_BUCKET=my-bucket
export AWS_S3_BUCKET_FAVICONS=my-bucket
export AWS_HOST=s3.fr-par.scw.cloud
export AWS_REGION=fr-par
export AWS_S3_STORAGE_CLASS=STANDARD
export ENTRY_IMAGE_HOST=my-bucket.s3.fr-par.scw.cloud
```

Fix #189 #241 