### PR TITLE
Undocumented ENV variable: AWS_S3_BUCKET_FAVICONS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ export RAILS_ENV=production
 export AWS_ACCESS_KEY_ID=
 export AWS_S3_BUCKET=
 export AWS_SECRET_ACCESS_KEY=
+# Leave empty if you want to use the same bucket for favicons
+export AWS_S3_BUCKET_FAVICONS=
 
 # Required to enable certain features
 export ANALYTICS_DOMAIN=

--- a/app/models/favicon_processor.rb
+++ b/app/models/favicon_processor.rb
@@ -1,6 +1,8 @@
 class FaviconProcessor
   attr_reader :data, :host
 
+  AWS_S3_BUCKET_FAVICONS = ENV["AWS_S3_BUCKET_FAVICONS"] || ENV["AWS_S3_BUCKET"]
+
   def initialize(data, host)
     @data = data
     @host = host
@@ -31,7 +33,7 @@ class FaviconProcessor
   def upload(data)
     upload_url = nil
     S3_POOL.with do |connection|
-      response = connection.put_object(ENV["AWS_S3_BUCKET_FAVICONS"], File.join(favicon_hash[0..2], "#{favicon_hash}.png"), data, s3_options)
+      response = connection.put_object(AWS_S3_BUCKET_FAVICONS, File.join(favicon_hash[0..2], "#{favicon_hash}.png"), data, s3_options)
       upload_url = URI::HTTP.build(
         scheme: "https",
         host: response.data[:host],


### PR DESCRIPTION
I am not sure with there is a different variable in the first place, but after spending a lot of time debugging my favicons, my understanding is that it's required.

This commit documents it in the example env file and add a fallback to `AWS_S3_BUCKET` if it's not set.