### PR TITLE
S3: Support non-AWS object storage for CarrierWave

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,7 +5,7 @@ if ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
       aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
       aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
       region: ENV["AWS_S3_REGION"] || "us-east-1",
-      host: ENV["AWS_HOST"] || "s3.amazonaws.com",
+      host: ENV["AWS_S3_HOST"] || "s3.amazonaws.com",
       endpoint: ENV["AWS_S3_ENDPOINT"] || nil,
       path_style: ENV["AWS_S3_PATH_STYLE"] || false,
     }

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -4,6 +4,10 @@ if ENV["AWS_ACCESS_KEY_ID"] && ENV["AWS_SECRET_ACCESS_KEY"]
       provider: "AWS",
       aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
       aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+      region: ENV["AWS_S3_REGION"] || "us-east-1",
+      host: ENV["AWS_HOST"] || "s3.amazonaws.com",
+      endpoint: ENV["AWS_S3_ENDPOINT"] || nil,
+      path_style: ENV["AWS_S3_PATH_STYLE"] || false,
     }
     config.fog_directory = ENV["AWS_S3_BUCKET"]
     config.max_file_size = 5.megabytes

--- a/config/initializers/s3.rb
+++ b/config/initializers/s3.rb
@@ -5,7 +5,7 @@ if ENV["AWS_ACCESS_KEY_ID"]
       aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
       aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
       region: ENV["AWS_S3_REGION"] || "us-east-1",
-      host: ENV["AWS_HOST"] || "s3.amazonaws.com",
+      host: ENV["AWS_S3_HOST"] || "s3.amazonaws.com",
       endpoint: ENV["AWS_S3_ENDPOINT"] || nil,
       path_style: ENV["AWS_S3_PATH_STYLE"] || false,
       persistent: true,


### PR DESCRIPTION
Same changes as for Fog.

Also I fixed a variable from my last PR.