### PR TITLE
Unfocus expand button after clicking

### DIFF
--- a/app/assets/javascripts/web/_site.js.coffee
+++ b/app/assets/javascripts/web/_site.js.coffee
@@ -1944,6 +1944,7 @@ $.extend feedbin,
     feedAction: ->
       $(document).on 'click', '[data-behavior~=feed_action]', (event) =>
         $(event.currentTarget).closest('form').submit()
+        event.currentTarget.blur()
         event.stopPropagation()
         event.preventDefault()
 


### PR DESCRIPTION
This will prevent pressing spacebar afterward from both toggling the button and navigating feeds.

To reproduce (firefox 89):
- click tag expand button (the `>` chevron)
- press spacebar