### PR TITLE
Cache user account migrations check

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -21,6 +21,13 @@ module SessionsHelper
     end
   end
 
+  def current_user_has_migrations?
+    if @current_user_has_migrations.nil?
+      @current_user_has_migrations = !!current_user.try(:account_migrations)&.exists?
+    end
+    @current_user_has_migrations
+  end
+
   def authorize
     unless signed_in?
       if request.subdomain == "api"

--- a/app/views/shared/_settings_nav.html.erb
+++ b/app/views/shared/_settings_nav.html.erb
@@ -94,7 +94,7 @@
             </span>
         <% end %>
     </li>
-    <% if current_user.try(:account_migrations)&.exists? %>
+    <% if current_user_has_migrations? %>
     <li>
         <%= link_to account_migrations_path, class: is_active?("account_migrations", "index") do %>
             <span class="icon-wrap">


### PR DESCRIPTION
`.exists?` call isn't cached so the query is run every time the menu is rendered - up to 50 calls on `EntriesController#preload` request.