### PR TITLE
Use ActiveSupport's `to_sentence` array conversion method when displaying authors

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -78,10 +78,7 @@ class Entry < ApplicationRecord
     authors = json_feed.safe_dig("authors")
     return authors unless authors.respond_to?(:filter_map)
     authors = authors.filter_map { _1&.safe_dig("name") }
-    if authors.length > 1
-      authors[-1] = "and #{authors[-1]}"
-    end
-    authors.join(", ")
+    authors.to_sentence
   rescue
     nil
   end

--- a/app/presenters/entry_presenter.rb
+++ b/app/presenters/entry_presenter.rb
@@ -225,10 +225,7 @@ class EntryPresenter < BasePresenter
       clean_author = @template.strip_tags(entry.author)
     elsif entry.data&.safe_dig("json_feed", "authors").respond_to?(:map)
       authors = entry.data.safe_dig("json_feed", "authors").map {|a| @template.strip_tags(a["name"]) }
-      if authors.length > 1
-        authors[-1] = "and #{authors[-1]}"
-      end
-      clean_author = authors.join(", ")
+      clean_author = authors.to_sentence
     else
       clean_author = ""
     end


### PR DESCRIPTION
## Description

The current entry model and presenter code generates an unnecessary comma when the feed entry (or feed itself) has two authors:

```
Author 1, and Author 2
```

…instead of:

```
Author 1 and Author 2
```

I noticed this on a JSON feed where the feed has two authors:

<img width="554" alt="image" src="https://github.com/feedbin/feedbin/assets/73866/bb4593d4-d7ee-446a-a03a-1c83da38155f">

## Solution

ActiveSupport's [`to_sentence` Array conversion method](https://github.com/rails/rails/blob/7-0-stable/activesupport/lib/active_support/core_ext/array/conversions.rb#L60) will handle joining 1, 2, and 3+ length arrays in a grammatically accurate fashion.

This PR makes the change to use `to_sentence` in the Entry model and EntryPresenter class.

Thanks for considering this change and for making and maintaining Feedbin!
