### PR TITLE
Improve feed listing line height

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1353,7 +1353,7 @@ $hamburger-dot: 4px;
         display: block;
         text-overflow: ellipsis;
         overflow: hidden;
-        line-height: 1.3;
+        line-height: normal;
         white-space: nowrap;
         &.hide {
           display: none;


### PR DESCRIPTION
This is a rather specific issue but I think the one I'm proposing here is a better value anyway.

![](https://s.kohaku.love/2024/03/firefox_2024-03-27_22-55-43.png)

Note the `g` in "Half as Interesting" is cut off. The screenshot is using japanese locale (Yu Gothic UI for system font), 90% zoom level, and firefox browser (tested and looked the same on both 115esr and 124). The other `g` isn't cut off which I believe it's the result of fractional scaling.

`normal` line height should guarantee the correct minimum value for any fonts and there's already separate padding between items so it should work fine.