### PR TITLE
Fix a stylesheet typo

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3343,7 +3343,8 @@ $feed-title-width: 115px;
   line-height: 1.6;
   @include color($color-contrast-600);
   text-rendering: optimizeLegibility;
-  overflow-wrap: break-word strong {
+  overflow-wrap: break-word;
+  strong {
     font-weight: 700;
     font-style: normal;
   }


### PR DESCRIPTION
I happened to inspect element and noticed this rule:

```
overflow-wrap: break-word strong;
```

Firefox shows a little warning icon and says that "break-word strong" is an "invalid property value". I think this looks like it's a typo, and I presume this is what it meant to say. Not sure how to test what this actually looks like, but figured I'd toss the PR over the fence for your consideration.