### PR TITLE
Fix color scheme for dark mode form fields

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -10,7 +10,7 @@
           <label for="email">Email</label>
         <% end %>
         <% text.input do %>
-          <%= email_field_tag :email, params[:email], autofocus: true, tabindex: "1", class: "peer text-input" %>
+          <%= email_field_tag :email, params[:email], autofocus: true, tabindex: "1", class: "peer text-input dark:[color-scheme:dark]" %>
         <% end %>
       <% end %>
     </div>
@@ -23,7 +23,7 @@
           </div>
         <% end %>
         <% text.input do %>
-          <%= password_field_tag :password, nil, tabindex: "2", class: "text-input" %>
+          <%= password_field_tag :password, nil, tabindex: "2", class: "text-input dark:[color-scheme:dark]" %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
Some browsers (like Edge) need to know that the form field is dark for them to display autofill content in those fields with the appropriate theme. Otherwise the proposed autofill content will be displayed in an ugly light-themed form field box.

I will note that this should be the appropriate fix for Tailwind CSS that I've used successfully in an another project, but as I can't really get Feedbin building in Docker (all the resources on it seem outdated), this hasn't been tested in a full clean build.