### PR TITLE
Add early return for empty video items in HarvestEmbeds

### DIFF
--- a/app/jobs/harvest_embeds.rb
+++ b/app/jobs/harvest_embeds.rb
@@ -49,7 +49,9 @@ class HarvestEmbeds
     def perform(ids)
       items = []
 
-      videos      = youtube_api(type: "videos", ids: ids, parts: ["snippet", "contentDetails", "liveStreamingDetails"])
+      videos = youtube_api(type: "videos", ids: ids, parts: ["snippet", "contentDetails", "liveStreamingDetails"])
+      return if videos.safe_dig("items").blank?
+
       channel_ids = videos.safe_dig("items")&.map { |video| video.safe_dig("snippet", "channelId") }.uniq
       channels    = youtube_api(type: "channels", ids: channel_ids, parts: ["snippet", "statistics", "brandingSettings"])
 


### PR DESCRIPTION
Encountered error:
```
feedbin_jobs.1  | 2025-10-26T07:52:44.942Z pid=11 tid=hdeb WARN: {"context":"Job raised exception","job":{"retry":true,"queue":"default","args":[["dUQQwOsIAP4","RIK0OY0QW9o","gvsSJwFfR3w","JJH7S-hdcNg","Dz5XLSPTpWA"]],"class":"HarvestEmbeds::Download","jid":"ebf6b7e9c0bc9f4c0bce84f5","created_at":1761439254.039915,"enqueued_at":1761465164.9377542,"error_message":"undefined method 'uniq' for nil","error_class":"NoMethodError","failed_at":1761439254.1874232,"retry_count":10,"retried_at":1761455071.3029833}}
```
