### PR TITLE
Fix NoMethodError when favicon download fails

### DIFF
--- a/app/jobs/favicon_crawler/finder.rb
+++ b/app/jobs/favicon_crawler/finder.rb
@@ -17,8 +17,8 @@ module FaviconCrawler
       new_favicon = nil
       all_favicon_urls.each do |url|
         response = download_favicon(url)
-        break if response.not_modified?
         next if response.blank?
+        break if response.not_modified?
         resized = Image.resize(response.path)
         next if resized.blank?
 

--- a/test/jobs/favicon_crawler/finder_test.rb
+++ b/test/jobs/favicon_crawler/finder_test.rb
@@ -123,5 +123,32 @@ module FaviconCrawler
 
       assert_nil Favicon.unscoped.where(host: @page_url.host).take
     end
+
+    test "should fall through to default location when icon download errors" do
+      body = <<-eot
+      <html>
+          <head>
+              <link rel="icon" href="#{@icon_url.path}">
+          </head>
+      </html>
+      eot
+
+      stub_request(:any, "https://s3.amazonaws.com/public-favicons/c7a9/c7a91374735634df325fbcfda3f4119278d36fc2.png")
+      stub_request(:any, "https://s3.amazonaws.com/c7a/c7a91374735634df325fbcfda3f4119278d36fc2.png")
+
+      stub_request(:get, @page_url)
+        .to_return(body: body, status: 200)
+
+      stub_request(:get, @icon_url)
+        .to_return(status: 429)
+
+      stub_request_file("favicon.ico", @default_url)
+
+      assert_nothing_raised do
+        Finder.new.perform(@page_url.host)
+      end
+
+      assert_not_nil Favicon.unscoped.where(host: @page_url.host).take!.favicon
+    end
   end
 end


### PR DESCRIPTION
## Problem

[metric error #12](https://metric.feedbin.cloud/errors/12) — `NoMethodError: undefined method 'not_modified?' for nil` in `FaviconCrawler::Finder`.

`download_favicon` returns `nil` whenever it rescues a `Feedkit::Error`. The production trigger was a `429 Too Many Requests` from `www.patreon.com`:

```
download_favicon exception=#<Feedkit::ClientError: 429 Too Many Requests> url=http://www.patreon.com/favicon.ico
```

The loop called `response.not_modified?` **before** the `next if response.blank?` nil-guard, so a failed download raised `NoMethodError` at `finder.rb:20` instead of moving on to the next candidate URL.

## Fix

Reorder the two guards so the nil/blank check runs first — a failed download now falls through to the next URL (e.g. the default `/favicon.ico`):

```ruby
response = download_favicon(url)
next if response.blank?
break if response.not_modified?
```

## Test

Added `should fall through to default location when icon download errors`, which stubs the icon URL to return `429`. Verified it reproduces the exact production `NoMethodError` without the fix and passes with it. Full suite: 1074 runs, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)