### PR TITLE
Fix NoMethodError when favicon homepage download fails

### DIFF
--- a/app/jobs/favicon_crawler/finder.rb
+++ b/app/jobs/favicon_crawler/finder.rb
@@ -75,7 +75,7 @@ module FaviconCrawler
       urls.push(default_favicon_location)
     rescue => exception
       Sidekiq.logger.info "find_meta_links exception=#{exception.inspect} host=#{@favicon.host}"
-      nil
+      [default_favicon_location]
     end
 
     def default_favicon_location

--- a/test/jobs/favicon_crawler/finder_test.rb
+++ b/test/jobs/favicon_crawler/finder_test.rb
@@ -124,6 +124,22 @@ module FaviconCrawler
       assert_nil Favicon.unscoped.where(host: @page_url.host).take
     end
 
+    test "should fall through to default location when homepage download errors" do
+      stub_request(:any, "https://s3.amazonaws.com/public-favicons/c7a9/c7a91374735634df325fbcfda3f4119278d36fc2.png")
+      stub_request(:any, "https://s3.amazonaws.com/c7a/c7a91374735634df325fbcfda3f4119278d36fc2.png")
+
+      stub_request(:get, @page_url)
+        .to_timeout
+
+      stub_request_file("favicon.ico", @default_url)
+
+      assert_nothing_raised do
+        Finder.new.perform(@page_url.host)
+      end
+
+      assert_not_nil Favicon.unscoped.where(host: @page_url.host).take!.favicon
+    end
+
     test "should fall through to default location when icon download errors" do
       body = <<-eot
       <html>


### PR DESCRIPTION
## Problem

[Metric error #9](https://metric.feedbin.cloud/errors/9): `NoMethodError: undefined method 'each' for nil` in `FaviconCrawler::Finder#update`.

`all_favicon_urls` rescues any exception raised while building the URL list and returned `nil`. When `download_homepage` raises — e.g. an `HTTP::ConnectTimeoutError` because the host is unreachable (the captured occurrence was `mail.beehiiv.com`) — the method returned `nil`, and `update` then called `nil.each`.

The recent #772 fix handled a *per-URL* download failure, but not the case where the *entire homepage fetch* fails and `all_favicon_urls` itself returns `nil`.

## Fix

Return `[default_favicon_location]` from the rescue instead of `nil`. This:

- Honors the method's contract of always returning an array, eliminating the crash.
- Preserves the existing "always try `/favicon.ico`" fallback, so a host with an unreachable homepage but a reachable `/favicon.ico` still resolves its favicon.

When the host is fully unreachable, `download_favicon` already rescues the failed `/favicon.ico` request and the loop completes without updating — no crash.

## Test

Added a regression test that stubs a homepage timeout and asserts the crawler falls through to the default favicon location without raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
