### PR TITLE
Add HTTP timeout to UrlCache to prevent worker timeouts

### DIFF
--- a/app/models/url_cache.rb
+++ b/app/models/url_cache.rb
@@ -22,7 +22,7 @@ class UrlCache
 
   def result
     @body, @headers = Rails.cache.fetch(cache_key) {
-      request = HTTP.follow(max_hops: 5).get(url, options)
+      request = HTTP.timeout(write: 5, connect: 5, read: 10).follow(max_hops: 5).get(url, options)
       [request.to_s, request.headers.to_h]
     }
   end


### PR DESCRIPTION
## Problem

`UrlCache` made outbound HTTP requests with no connect/read timeout (`app/models/url_cache.rb`). When an upstream host hung, the request blocked until pitchfork's 30s worker timeout (`config/pitchfork.rb`) force-killed the worker, which surfaced as `SystemExit: exit`.

This is what caused [error #47](https://metric.feedbin.cloud/errors/47): a request to `EmbedsController#iframe` for `https://share.newsroom.apple/newsroom/embed/videos/?embedvideoid=…`. The host matches no known provider, so it falls through to `IframeEmbed::Default`, whose `#title` reads `UrlCache#body` during template rendering. The Apple URL never responded, the partial render sat at exactly 30.000s, and the worker was killed — the entire backtrace is pitchfork frames with no app frames.

Note: the controller's bare `rescue` can't catch this, since `SystemExit` descends from `Exception`, not `StandardError`. The real fix is to stop the hang.

## Fix

Add the same timeouts already used across the codebase (`Download`, `MercuryParser`, etc.):

```ruby
HTTP.timeout(write: 5, connect: 5, read: 10).follow(max_hops: 5).get(url, options)
```

A slow upstream now raises a rescuable `HTTP::TimeoutError` well under the 30s worker timeout, so `EmbedsController#iframe`'s `rescue` renders the `error` partial instead of taking down the worker.

## Testing

`bundle exec rake test TEST=test/models/url_cache_test.rb` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)