### PR TITLE
Fix NoMethodError when newsletter email has no To header

### DIFF
--- a/app/models/email_newsletter.rb
+++ b/app/models/email_newsletter.rb
@@ -24,7 +24,7 @@ class EmailNewsletter
   end
 
   def to_email
-    parsed_to.address
+    parsed_to&.address
   end
 
   def from_name
@@ -110,7 +110,7 @@ class EmailNewsletter
   end
 
   def parsed_to
-    @email[:to].element.addresses.first
+    @email[:to]&.element&.addresses&.first
   end
 
 end

--- a/test/models/email_newsletter_test.rb
+++ b/test/models/email_newsletter_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class EmailNewsletterTest < ActiveSupport::TestCase
+  test "to_email returns nil when To header is missing" do
+    source = <<~EMAIL
+      From: Ben Ubois <ben@benubois.com>
+      Subject: No To Header
+      Date: Tue, 18 May 2021 14:16:22 -0700
+
+      This is a plain text email with no To header.
+    EMAIL
+
+    newsletter = EmailNewsletter.new(Mail.from_source(source), "token")
+
+    assert_nil newsletter.to_email
+  end
+
+  test "to_email returns the address when To header is present" do
+    source = <<~EMAIL
+      From: Ben Ubois <ben@benubois.com>
+      To: token@newsletters.feedbin.com
+      Subject: Has To Header
+      Date: Tue, 18 May 2021 14:16:22 -0700
+
+      This is a plain text email.
+    EMAIL
+
+    newsletter = EmailNewsletter.new(Mail.from_source(source), "token")
+
+    assert_equal "token@newsletters.feedbin.com", newsletter.to_email
+  end
+end


### PR DESCRIPTION
## Problem

`NewsletterReceiver` was raising `NoMethodError: undefined method 'element' for nil` (~140 occurrences) at `EmailNewsletter#parsed_to`:

```ruby
def parsed_to
  @email[:to].element.addresses.first
end
```

When an incoming newsletter has no `To:` header — common when the subscriber address is delivered via BCC / undisclosed-recipients and the real recipient comes from the SMTP envelope rather than the message header — `@email[:to]` is `nil`, so `.element` raises.

## Fix

Use safe navigation in `parsed_to`/`to_email` so a missing `To:` header yields `nil` instead of crashing. This matches the nil-tolerant idiom already used elsewhere in the model (`text_part&.decoded`, `content_type&.strip`, `List-Unsubscribe&.decoded`). `to_email` only feeds the optional `newsletter_to` metadata column, so `nil` is acceptable.

## Test

Added `test/models/email_newsletter_test.rb` covering both the missing-header case (previously reproduced the exact `NoMethodError`) and the present-header case.