### PR TITLE
Fix NoMethodError when newsletter email is multipart with no text or html part

### DIFF
--- a/app/models/email_newsletter.rb
+++ b/app/models/email_newsletter.rb
@@ -44,11 +44,11 @@ class EmailNewsletter
   end
 
   def text
-    to_utf8(@email.text_part&.decoded || !html? && @email.decoded || nil)
+    to_utf8(@email.text_part&.decoded || (!html? && decoded_body) || nil)
   end
 
   def html
-    to_utf8(@email.html_part&.decoded || html? && @email.decoded || nil)
+    to_utf8(@email.html_part&.decoded || (html? && decoded_body) || nil)
   end
 
   def content
@@ -103,6 +103,12 @@ class EmailNewsletter
     return value unless value.is_a?(String)
     value = value.dup.force_encoding(Encoding::UTF_8) unless value.encoding == Encoding::UTF_8
     value.valid_encoding? ? value : value.scrub
+  end
+
+  # Mail::Message#decoded raises NoMethodError on a multipart message, so only
+  # fall back to the whole-message body when there is a single decodable body.
+  def decoded_body
+    @email.decoded unless @email.multipart?
   end
 
   def html?

--- a/test/models/email_newsletter_test.rb
+++ b/test/models/email_newsletter_test.rb
@@ -54,4 +54,32 @@ class EmailNewsletterTest < ActiveSupport::TestCase
       assert value.valid_encoding?
     end
   end
+
+  test "text and content are nil when a multipart email has no text or html part" do
+    # A multipart message with neither a text/plain nor a text/html part (here,
+    # only an image attachment). Mail::Message#decoded raises NoMethodError on a
+    # multipart message, so the whole-message fallback must not be reached.
+    source = <<~EMAIL
+      From: Ben Ubois <ben@benubois.com>
+      To: token@newsletters.feedbin.com
+      Subject: Multipart with no body
+      Date: Tue, 18 May 2021 14:16:22 -0700
+      Content-Type: multipart/mixed; boundary="boundary"
+
+      --boundary
+      Content-Type: image/png
+      Content-Transfer-Encoding: base64
+      Content-Disposition: attachment; filename="pixel.png"
+
+      iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==
+
+      --boundary--
+    EMAIL
+
+    newsletter = EmailNewsletter.new(Mail.from_source(source), "token")
+
+    assert_nil newsletter.text
+    assert_nil newsletter.html
+    assert_nil newsletter.content
+  end
 end


### PR DESCRIPTION
## Problem

`NewsletterReceiver` was crashing with `NoMethodError: This message cannot be decoded as _entire_ message...` raised from `Mail::Message#decoded`.

`EmailNewsletter#text` and `#html` fall back to decoding the whole message body when no `text_part`/`html_part` is found:

```ruby
to_utf8(@email.text_part&.decoded || !html? && @email.decoded || nil)
```

`Mail::Message#decoded` raises `NoMethodError` for a multipart message. When a multipart email has neither a `text/plain` nor a `text/html` part (e.g. only an attachment), the fallback reached `@email.decoded` on the multipart message and raised.

## Fix

Guard the whole-message fallback behind `!@email.multipart?` via a `decoded_body` helper, so it is only used for single-part messages. Multipart emails with no usable body part now yield `nil` content instead of crashing.

## Test

Added a test with a multipart/mixed email containing only an attachment, asserting `text`, `html`, and `content` return `nil`.