### PR TITLE
Make CacheRemoteFile idempotent to avoid duplicate fingerprint errors

### DIFF
--- a/app/jobs/image_crawler/cache_remote_file.rb
+++ b/app/jobs/image_crawler/cache_remote_file.rb
@@ -19,13 +19,12 @@ module ImageCrawler
 
     def perform(url, image)
       fingerprint = url.split("-").first
-      RemoteFile.create!(
-        fingerprint: fingerprint,
+      RemoteFile.create_with(
         original_url: image["original_url"],
         storage_url: image["processed_url"],
         width: image["width"],
         height: image["height"],
-      )
+      ).create_or_find_by!(fingerprint: fingerprint)
     end
   end
 end

--- a/test/jobs/image_crawler/cache_remote_file_test.rb
+++ b/test/jobs/image_crawler/cache_remote_file_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+module ImageCrawler
+  class CacheRemoteFileTest < ActiveSupport::TestCase
+    def setup
+      @url = "bc5431c75680852f26ff34e4688af32b-icon"
+      @image = {
+        "original_url" => "https://example.com/avatar.jpg",
+        "processed_url" => "https://files.example.com/bc5/bc5431c75680852f26ff34e4688af32b-icon.jpg",
+        "width" => 240,
+        "height" => 240,
+      }
+    end
+
+    test "creates a remote file" do
+      assert_difference "RemoteFile.count", 1 do
+        CacheRemoteFile.new.perform(@url, @image)
+      end
+
+      remote_file = RemoteFile.find_by(fingerprint: "bc5431c75680852f26ff34e4688af32b")
+      assert_equal @image["original_url"], remote_file.original_url
+      assert_equal @image["processed_url"], remote_file.storage_url
+      assert_equal @image["width"], remote_file.width
+      assert_equal @image["height"], remote_file.height
+    end
+
+    test "is idempotent when the fingerprint already exists" do
+      CacheRemoteFile.new.perform(@url, @image)
+
+      assert_no_difference "RemoteFile.count" do
+        assert_nothing_raised do
+          CacheRemoteFile.new.perform(@url, @image)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`ImageCrawler::CacheRemoteFile#perform` unconditionally called `RemoteFile.create!`, which raised `ActiveRecord::RecordNotUnique` (`PG::UniqueViolation` on `index_remote_files_on_fingerprint`) whenever a `RemoteFile` with the same fingerprint already existed — e.g. the same icon scheduled to be cached more than once or concurrently. The job is configured with `retry: false`, so the duplicate insert surfaced as an error instead of being a harmless no-op.

## Fix

Use the `create_with(...).create_or_find_by!` pattern already established elsewhere in the codebase (e.g. `Feed`). It attempts the insert and, on a unique-constraint violation, finds the existing row instead — making the job idempotent and safe against the concurrent-insert race.

## Tests

Added `test/jobs/image_crawler/cache_remote_file_test.rb`:
- creates a remote file with the expected attributes
- is idempotent when the fingerprint already exists (reproduces the original error against the old code; passes with the fix)