### PR TITLE
Don't report expected upstream Feedkit errors from FeedFinder

### DIFF
--- a/app/models/feed_finder.rb
+++ b/app/models/feed_finder.rb
@@ -58,7 +58,10 @@ class FeedFinder
     else
       Rails.logger.error exception.message
       Rails.logger.error exception.backtrace.join("\n")
-      ErrorService.notify(exception)
+      # Feedkit::Error means the user's URL itself failed to fetch/parse
+      # (connection refused, 4xx/5xx, timeout, SSL, etc). That's an expected
+      # upstream condition, not a bug, so log it but don't report it.
+      ErrorService.notify(exception) unless exception.is_a?(Feedkit::Error)
       feeds
     end
   end

--- a/test/models/feed_finder_test.rb
+++ b/test/models/feed_finder_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class FeedFinderTest < ActiveSupport::TestCase
+  test "upstream Feedkit error is swallowed without notifying" do
+    url = "http://upstream-fails.example.com/"
+    stub_request(:get, url).to_return(status: 429)
+
+    notified = []
+    ErrorService.stub(:notify, ->(exception, *) { notified << exception }) do
+      result = FeedFinder.feeds(url)
+      assert_equal [], result, "expected empty feeds when upstream fails"
+    end
+
+    assert_empty notified, "expected upstream Feedkit errors not to be reported"
+  end
+
+  test "unexpected (non-Feedkit) errors are still notified" do
+    url = "http://boom.example.com/"
+    stub_request(:get, url).to_return(status: 200, body: "ok")
+
+    notified = []
+    boom = RuntimeError.new("unexpected")
+    # Force a non-Feedkit failure during source resolution.
+    Source::ExistingFeed.stub(:find, ->(*) { raise boom }) do
+      ErrorService.stub(:notify, ->(exception, *) { notified << exception }) do
+        result = FeedFinder.feeds(url)
+        assert_equal [], result
+      end
+    end
+
+    assert_equal [boom], notified, "expected genuine bugs to still be reported"
+  end
+end


### PR DESCRIPTION
## Problem

`FeedFinder.feeds` fetches arbitrary user-supplied URLs. When the upstream host fails — connection refused, 4xx/5xx, timeout, SSL error, redirect loops, gzip errors, etc. — Feedkit raises a `Feedkit::Error`. `FeedFinder#find` already rescues these, logs them, **reports them via `ErrorService`**, and returns no feeds, so the request completes gracefully (the user just sees "no feed found").

The reporting is pure noise: these are expected upstream conditions, not application bugs. They have been flooding the error tracker from every URL-resolving entry point (the feed search action and the browser-extension subscriptions endpoint, both of which funnel through `FeedFinder.feeds`).

## Change

Skip `ErrorService.notify` for `Feedkit::Error` in `FeedFinder#find`, while still logging it. Genuine, unexpected errors during source resolution continue to be reported, so real bugs are unaffected.

## Tests

Added `test/models/feed_finder_test.rb`:
- an upstream `Feedkit::Error` is swallowed **without** notifying
- a non-Feedkit error during resolution is **still** notified

Existing feeds controller, extension subscriptions, and feed-importer tests still pass.
