### PR TITLE
Return a String from Entry#rebase_url

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -119,7 +119,7 @@ class Entry < ApplicationRecord
 
     base = Addressable::URI.heuristic_parse(fully_qualified_url)
     original_url = Addressable::URI.heuristic_parse(original_url)
-    Addressable::URI.join(base, original_url)
+    Addressable::URI.join(base, original_url).to_s
   rescue Addressable::URI::InvalidURIError
     Rails.logger.error("Invalid uri original_url=#{original_url} fully_qualified_url=#{fully_qualified_url}")
     nil

--- a/test/models/entry_test.rb
+++ b/test/models/entry_test.rb
@@ -103,6 +103,19 @@ class EntryTest < ActiveSupport::TestCase
     assert_equal("http://daringfireball.net/test", @entry.fully_qualified_url)
   end
 
+  test "rebase_url returns a String for absolute urls" do
+    result = @entry.rebase_url("http://example.com/podcast.mp3")
+    assert_instance_of String, result
+    assert_equal("http://example.com/podcast.mp3", result)
+  end
+
+  test "rebase_url returns a String for relative urls" do
+    @entry.url = "http://daringfireball.net/episode"
+    result = @entry.rebase_url("/podcast.mp3")
+    assert_instance_of String, result
+    assert_equal("http://daringfireball.net/podcast.mp3", result)
+  end
+
   test "should use JSON feed author" do
     @entry.update(data: {
       json_feed: {


### PR DESCRIPTION
## Problem

`entries#preload` raised `ArgumentError: Can't resolve audio into URL: undefined method 'to_model' for an instance of Addressable::URI` (metric error #52, first seen right after the Rails 8.1 deploy).

`Entry#rebase_url` returned a `String` when the URL was already absolute, but an `Addressable::URI` object from the relative-join branch. Rails 8.1's `audio_tag` treats any non-String source as a model and calls `polymorphic_url` → `to_model` on it. `Addressable::URI` doesn't respond to `to_model`, so rendering `_audio_markup.html.erb` blew up for any entry whose enclosure URL was relative.

The inconsistent return type also broke `ChapterParser`, which feeds the result into `Digest::SHA1.hexdigest` (requires a String).

## Fix

Coerce the joined URI with `.to_s` so `rebase_url` returns a `String` for every branch, matching the already-absolute path.

## Tests

Added `EntryTest` coverage asserting `rebase_url` returns a `String` for both absolute and relative inputs. The relative case failed before the fix and passes now; full `entry_test.rb` and `image_crawler/entry_image_test.rb` suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
