### PR TITLE
Fix concurrent insert race in StarredEntry and UnreadEntry

### DIFF
--- a/app/models/starred_entry.rb
+++ b/app/models/starred_entry.rb
@@ -12,9 +12,15 @@ class StarredEntry < ApplicationRecord
   end
 
   def self.create_from_owners(user, entry, source = nil)
-    result = new_from_owners(user, entry, source)
-    result.save
-    result
+    # Look up / insert by the columns the unique index covers so that a
+    # concurrent request which wins the race is recovered via find_by rather
+    # than raising RecordNotUnique. The remaining attributes are only applied
+    # on the create path.
+    create_or_find_by(user_id: user.id, entry_id: entry.id) do |starred_entry|
+      starred_entry.feed_id = entry.feed_id
+      starred_entry.published = entry.published
+      starred_entry.source = source
+    end
   end
 
   def expire_caches

--- a/app/models/unread_entry.rb
+++ b/app/models/unread_entry.rb
@@ -12,7 +12,15 @@ class UnreadEntry < ApplicationRecord
   end
 
   def self.create_from_owners(user, entry)
-    new_from_owners(user, entry).save
+    # Look up / insert by the columns the unique index covers so that a
+    # concurrent request which wins the race is recovered via find_by rather
+    # than raising RecordNotUnique. The remaining attributes are only applied
+    # on the create path.
+    create_or_find_by(user_id: user.id, entry_id: entry.id) do |unread_entry|
+      unread_entry.feed_id = entry.feed_id
+      unread_entry.published = entry.published
+      unread_entry.entry_created_at = entry.created_at
+    end
   end
 
   def self.sort_preference(sort)

--- a/test/models/starred_entry_test.rb
+++ b/test/models/starred_entry_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "minitest/stub_any_instance"
 
 class StarredEntryTest < ActiveSupport::TestCase
   setup do
@@ -26,6 +27,24 @@ class StarredEntryTest < ActiveSupport::TestCase
     StarredEntry.create_from_owners(@user, @entry)
     duplicate = StarredEntry.new_from_owners(@user, @entry)
     refute duplicate.valid?
+  end
+
+  test "create_from_owners returns the existing record when a concurrent insert wins the race" do
+    original = StarredEntry.create_from_owners(@user, @entry)
+
+    # Simulate the check-then-insert race: the uniqueness validation passes
+    # (as it would when a concurrent request hasn't committed yet) but the DB
+    # unique index rejects the duplicate INSERT. create_or_find_by recovers by
+    # returning the row the winning request already committed.
+    result = StarredEntry.stub_any_instance(:valid?, true) do
+      assert_nothing_raised do
+        StarredEntry.create_from_owners(@user, @entry)
+      end
+    end
+
+    assert_predicate result, :persisted?
+    assert_equal original.id, result.id
+    assert_equal 1, StarredEntry.where(user: @user, entry: @entry).count
   end
 
   test "expire_caches deletes the user's starred feed cache" do

--- a/test/models/unread_entry_test.rb
+++ b/test/models/unread_entry_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+require "minitest/stub_any_instance"
+
+class UnreadEntryTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:new)
+    @entry = create_feeds(@user, 1).first.entries.first
+    # An unread is created automatically when the feed/entry is set up; start
+    # each test from a clean slate so create_from_owners is exercised directly.
+    UnreadEntry.where(user: @user, entry: @entry).delete_all
+  end
+
+  test "create_from_owners persists the record" do
+    assert_difference "UnreadEntry.count", +1 do
+      UnreadEntry.create_from_owners(@user, @entry)
+    end
+  end
+
+  test "create_from_owners returns the existing record when a concurrent insert wins the race" do
+    original = UnreadEntry.create_from_owners(@user, @entry)
+    assert_predicate original, :persisted?
+
+    # Simulate the check-then-insert race: the uniqueness validation passes
+    # (as it would when a concurrent request hasn't committed yet) but the DB
+    # unique index rejects the duplicate INSERT. create_or_find_by recovers by
+    # returning the row the winning request already committed.
+    result = UnreadEntry.stub_any_instance(:valid?, true) do
+      assert_nothing_raised do
+        UnreadEntry.create_from_owners(@user, @entry)
+      end
+    end
+
+    assert_predicate result, :persisted?
+    assert_equal original.id, result.id
+    assert_equal 1, UnreadEntry.where(user: @user, entry: @entry).count
+  end
+end


### PR DESCRIPTION
## Problem

`POST /v2/starred_entries` intermittently returns a 500 with `ActiveRecord::RecordNotUnique` (`PG::UniqueViolation` on `index_starred_entries_on_user_id_and_entry_id`).

This is a check-then-insert race. `StarredEntry` relies on `validates_uniqueness_of :user_id, scope: :entry_id`, which issues a `SELECT` before the `INSERT`. When two requests star the same entry concurrently, both pass the validation before either commits, and the second `INSERT` is rejected by the database unique index — raising `RecordNotUnique` and failing the request with a 500.

`UnreadEntry` has the identical pattern (same `validates_uniqueness_of`, same `unreads` unique index on `(user_id, entry_id)`) and the same latent race, so it is fixed here too.

## Fix

Use `create_or_find_by` in both `create_from_owners` methods, keyed on the columns the unique index covers (`user_id`, `entry_id`). When a concurrent request wins the race, the losing request recovers by returning the row that was already committed instead of raising.

The remaining attributes (`feed_id`, `published`, `source` / `entry_created_at`) are applied only on the create path via the block, so the `find_by` fallback matches the unique index regardless of those values. For `StarredEntry` the `counter_cache` increment and `before_create :expire_caches` callback still run on the create path (a raw `INSERT ... ON CONFLICT` would have bypassed both); on the find path the winning request has already run them.

## Test

Each model has a test that reproduces the race by letting the uniqueness validation pass while the row already exists (mirroring the uncommitted-concurrent-request window). Each asserts the duplicate INSERT no longer raises, that the returned record is the existing persisted row, and that only one row exists. `UnreadEntryTest` is new (none existed for that model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)