### PR TITLE
Guard against nil response when logging Feedkit errors

### DIFF
--- a/app/jobs/feed_crawler/downloader.rb
+++ b/app/jobs/feed_crawler/downloader.rb
@@ -46,7 +46,7 @@ module FeedCrawler
     rescue Feedkit::Error => exception
       @crawl_data.download_error(exception)
       message = "Feedkit::Error: attempts=#{@crawl_data.error_count} exception=#{exception.inspect} id=#{@feed_id} url=#{@feed_url} next_retry=#{@crawl_data.relative_retry_after}"
-      if exception.respond_to?(:response)
+      if exception.respond_to?(:response) && exception.response
         message = "#{message} server=#{exception.response.headers[:server]}"
       end
       Sidekiq.logger.info message

--- a/test/jobs/feed_crawler/downloader_test.rb
+++ b/test/jobs/feed_crawler/downloader_test.rb
@@ -176,6 +176,15 @@ module FeedCrawler
       assert_equal(2, @feed.reload.crawl_data.error_count)
     end
 
+    def test_should_handle_error_with_nil_response
+      url = "http://example.com/atom.xml"
+      Feedkit::Request.stub(:download, ->(*) { raise Feedkit::ServerError.new("500 Internal Server Error", nil) }) do
+        assert_nothing_raised do
+          Downloader.new.perform(1, url, 10, {})
+        end
+      end
+    end
+
     def test_should_follow_redirects
       first_url = "http://www.example.com"
       last_url = "#{first_url}/final"


### PR DESCRIPTION
## Problem

`FeedCrawler::Downloader#download` raised `NoMethodError: undefined method 'headers' for nil` while handling a Feedkit error, masking the original download failure:

```ruby
if exception.respond_to?(:response)
  message = "#{message} server=#{exception.response.headers[:server]}"
end
```

`Feedkit::ResponseError` defines a `#response` reader that can be `nil`. The curl download path raises `ServerError.new(status, nil)`, so `respond_to?(:response)` is true but `exception.response` is `nil`, and reading `.headers` blows up. The job then errors out instead of logging the real upstream error.

## Fix

Require `exception.response` to be present before reading its headers.

## Test

Added a regression test that raises a `Feedkit::ServerError` with a nil response and asserts the downloader handles it without raising. It fails on `main` with the exact production error and passes with the fix.